### PR TITLE
fix:get server list with health node

### DIFF
--- a/spring-cloud-tencent-starters/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/ribbon/PolarisServerList.java
+++ b/spring-cloud-tencent-starters/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/ribbon/PolarisServerList.java
@@ -53,7 +53,7 @@ public class PolarisServerList extends AbstractServerList<Server> {
     }
 
     private List<Server> getServers() {
-        InstancesResponse filteredInstances = polarisDiscoveryHandler.getInstances(serviceId);
+        InstancesResponse filteredInstances = polarisDiscoveryHandler.getFilteredInstances(serviceId);
         ServiceInstances serviceInstances = filteredInstances.toServiceInstances();
         List<Server> polarisServers = new ArrayList<>();
         for (Instance instance : serviceInstances.getInstances()) {


### PR DESCRIPTION
## PR Type

Bugfix.

## Describe what this PR does for and how you did.

Use `PolarisDiscoveryHandler.getFilteredInstances` instead of `PolarisDiscoveryHandler.getInstances` when getting nodes of one service to get **HEALTHY** node.

## Does this PR be associated with issue? If so, please adding the issue link below.

#23

## Note


### Checklist
- [x] Code compiles correctly
- [ ] Create at least one junit test if possible
- [x] All tests passing
- [ ] Extend documentation if necessary
- [x] Add myself / the copyright holder to the AUTHORS file