### PR TITLE
fix json-related flaky tests

### DIFF
--- a/spring-cloud-tencent-starters/spring-cloud-tencent-metadata/src/test/java/com/tencent/cloud/metadata/core/intercepter/feign/Metadata2HeaderFeignInterceptorTest.java
+++ b/spring-cloud-tencent-starters/spring-cloud-tencent-metadata/src/test/java/com/tencent/cloud/metadata/core/intercepter/feign/Metadata2HeaderFeignInterceptorTest.java
@@ -17,6 +17,8 @@
 
 package com.tencent.cloud.metadata.core.intercepter.feign;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tencent.cloud.metadata.config.MetadataLocalProperties;
 import com.tencent.cloud.metadata.constant.MetadataConstant;
 import com.tencent.cloud.metadata.context.MetadataContextHolder;
@@ -61,10 +63,11 @@ public class Metadata2HeaderFeignInterceptorTest {
     private TestApplication.TestFeign testFeign;
 
     @Test
-    public void test1() {
+    public void test1() throws JsonProcessingException {
         String metadata = testFeign.test();
-        Assertions.assertThat(metadata).isEqualTo("{\"a\":\"11\",\"b\":\"22\",\"c\":\"33\"}{\"LOCAL_SERVICE\":\"test"
-                + "\",\"LOCAL_PATH\":\"/test\",\"LOCAL_NAMESPACE\":\"default\"}");
+        ObjectMapper mapper = new ObjectMapper();
+        Assertions.assertThat(mapper.readTree(metadata)).isEqualTo(mapper.readTree("{\"a\":\"11\",\"b\":\"22\",\"c\":\"33\"}{\"LOCAL_SERVICE\":\"test"
+                + "\",\"LOCAL_PATH\":\"/test\",\"LOCAL_NAMESPACE\":\"default\"}"));
         Assertions.assertThat(metadataLocalProperties.getContent().get("a")).isEqualTo("1");
         Assertions.assertThat(metadataLocalProperties.getContent().get("b")).isEqualTo("2");
         Assertions.assertThat(MetadataContextHolder.get().getTransitiveCustomMetadata("a")).isEqualTo("11");

--- a/spring-cloud-tencent-starters/spring-cloud-tencent-metadata/src/test/java/com/tencent/cloud/metadata/core/intercepter/resttemplate/MetadataRestTemplateInterceptorTest.java
+++ b/spring-cloud-tencent-starters/spring-cloud-tencent-metadata/src/test/java/com/tencent/cloud/metadata/core/intercepter/resttemplate/MetadataRestTemplateInterceptorTest.java
@@ -17,6 +17,8 @@
 
 package com.tencent.cloud.metadata.core.intercepter.resttemplate;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tencent.cloud.metadata.config.MetadataLocalProperties;
 import com.tencent.cloud.metadata.constant.MetadataConstant;
 import com.tencent.cloud.metadata.context.MetadataContextHolder;
@@ -65,14 +67,15 @@ public class MetadataRestTemplateInterceptorTest {
     private int localServerPort;
 
     @Test
-    public void test1() {
+    public void test1() throws JsonProcessingException {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.set(MetadataConstant.HeaderName.CUSTOM_METADATA, "{\"a\":\"11\",\"b\":\"22\",\"c\":\"33\"}");
         HttpEntity<String> httpEntity = new HttpEntity<>(httpHeaders);
         String metadata = restTemplate.exchange("http://localhost:" + localServerPort + "/test",
                 HttpMethod.GET, httpEntity, String.class).getBody();
-        Assertions.assertThat(metadata).isEqualTo("{\"a\":\"11\",\"b\":\"22\",\"c\":\"33\"}{\"LOCAL_SERVICE\":\"test"
-                + "\",\"LOCAL_PATH\":\"/test\",\"LOCAL_NAMESPACE\":\"default\"}");
+        ObjectMapper mapper = new ObjectMapper();
+        Assertions.assertThat(mapper.readTree(metadata)).isEqualTo(mapper.readTree("{\"a\":\"11\",\"b\":\"22\",\"c\":\"33\"}{\"LOCAL_SERVICE\":\"test"
+                + "\",\"LOCAL_PATH\":\"/test\",\"LOCAL_NAMESPACE\":\"default\"}"));
         Assertions.assertThat(metadataLocalProperties.getContent().get("a")).isEqualTo("1");
         Assertions.assertThat(metadataLocalProperties.getContent().get("b")).isEqualTo("2");
         Assertions.assertThat(MetadataContextHolder.get().getTransitiveCustomMetadata("a")).isEqualTo("11");


### PR DESCRIPTION
## PR Type
<!--
Bugfix.
Feature.
Code style update (formatting, local variables).
Refactoring (no functional changes, no api changes).
Documentation content changes.
Other... Please describe:
 -->
This PR makes two unit tests account for non-determinism.

## Describe what this PR does for and how you did.
The tests `com.tencent.cloud.metadata.core.intercepter.feign.Metadata2HeaderFeignInterceptorTest.test1` and `com.tencent.cloud.metadata.core.intercepter.resttemplate.MetadataRestTemplateInterceptorTest.test1` could fail based on the order of the fields in a JSON string. This was found using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

To ignore the ordering of the fields, I used `Jackson` to parse the JSON strings. Then, these `JsonNode` objects can be compared directly.

## Does this PR be associated with issue? If so, please adding the issue link below.
No

### Checklist
- [x] Code compiles correctly
- [x] Create at least one junit test if possible
- [x] All tests passing
- [x] Extend documentation if necessary
- [x] Add myself / the copyright holder to the AUTHORS file