### PR TITLE
fix: shutdown thread pool before the container closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@
 - [UT: add metadata-transfer unit test](https://github.com/Tencent/spring-cloud-tencent/pull/335)
 - [feat:Add GitHub action of codecov.yml and update junit of metadata.](https://github.com/Tencent/spring-cloud-tencent/pull/344)
 - [Feature: optimize static metadata manager](https://github.com/Tencent/spring-cloud-tencent/pull/346)
+- [fix: shutdown thread pool before the container closes](https://github.com/Tencent/spring-cloud-tencent/pull/354)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,4 @@
 - [UT: add metadata-transfer unit test](https://github.com/Tencent/spring-cloud-tencent/pull/335)
 - [feat:Add GitHub action of codecov.yml and update junit of metadata.](https://github.com/Tencent/spring-cloud-tencent/pull/344)
 - [Feature: optimize static metadata manager](https://github.com/Tencent/spring-cloud-tencent/pull/346)
-- [fix: shutdown thread pool before the container closes](https://github.com/Tencent/spring-cloud-tencent/pull/354)
+- [fix: shutdown thread pool before the container closes](https://github.com/Tencent/spring-cloud-tencent/pull/355)

--- a/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/discovery/refresh/PolarisRefreshApplicationReadyEventListener.java
+++ b/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/discovery/refresh/PolarisRefreshApplicationReadyEventListener.java
@@ -25,6 +25,7 @@ import com.tencent.polaris.client.util.NamedThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
 import org.springframework.context.ApplicationEventPublisher;
@@ -38,7 +39,7 @@ import static com.tencent.cloud.polaris.discovery.refresh.PolarisServiceStatusCh
  *
  * @author Haotian Zhang
  */
-public class PolarisRefreshApplicationReadyEventListener implements ApplicationListener<ApplicationReadyEvent>, ApplicationEventPublisherAware {
+public class PolarisRefreshApplicationReadyEventListener implements ApplicationListener<ApplicationReadyEvent>, ApplicationEventPublisherAware, DisposableBean {
 
 	private static final Logger LOG = LoggerFactory.getLogger(PolarisRefreshApplicationReadyEventListener.class);
 	private static final int DELAY = 60;
@@ -82,5 +83,10 @@ public class PolarisRefreshApplicationReadyEventListener implements ApplicationL
 	@Override
 	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
 		this.publisher = applicationEventPublisher;
+	}
+
+	@Override
+	public void destroy() throws Exception {
+		refreshExecutor.shutdown();
 	}
 }


### PR DESCRIPTION
## PR Type

Bugfix.

## Describe what this PR does for and how you did.

Shutdown the thread pool before the spring container closes.

## Adding the issue link (#xxx) if possible.

https://github.com/Tencent/spring-cloud-tencent/issues/352

## Note

## Checklist

- [x] Add copyright holder at the beginning of .class file if it is new.
- [x] Add information of this PR to CHANGELOG.md in root of project.
- [x] All junit tests passing.
- [x] Coverage from `Codecov Report` should not decrease.

## Checklist (Optional)

- [x] Will Pull Request to branch of 2020.0 and 2021.0.
- [x] Add documentation in javadoc in code or comment below the PR if necessary.
- [x] Add your name as @author to the beginning of .class file.
