### PR TITLE
Fix javadoc <br /> error in 2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@
 - [docs:update logo in README.](https://github.com/Tencent/spring-cloud-tencent/pull/359)
 - [Use jdk constants instead of magic variables](https://github.com/Tencent/spring-cloud-tencent/pull/362)
 - [Refator JacksonUtils and JacksonUtilsTest](https://github.com/Tencent/spring-cloud-tencent/pull/366)
+- [docs: Fix javadoc <br /> error](https://github.com/Tencent/spring-cloud-tencent/pull/371)

--- a/spring-cloud-starter-tencent-polaris-config/src/main/java/com/tencent/cloud/polaris/config/annotation/PolarisConfigKVFileChangeListener.java
+++ b/spring-cloud-starter-tencent-polaris-config/src/main/java/com/tencent/cloud/polaris/config/annotation/PolarisConfigKVFileChangeListener.java
@@ -38,7 +38,7 @@ public @interface PolarisConfigKVFileChangeListener {
 
 	/**
 	 * The keys interested in the listener, will only be notified if any of the interested keys is changed.
-	 * <br />
+	 * <p>
 	 * If neither of {@code interestedKeys} and {@code interestedKeyPrefixes} is specified then the {@code listener} will be notified when any key is changed.
 	 * @return interested keys in the listener
 	 */
@@ -49,7 +49,7 @@ public @interface PolarisConfigKVFileChangeListener {
 	 * The prefixes will simply be used to determine whether the {@code listener} should be notified or not using {@code changedKey.startsWith(prefix)}.
 	 * e.g. "spring." means that {@code listener} is interested in keys that starts with "spring.", such as "spring.banner", "spring.jpa", etc.
 	 * and "application" means that {@code listener} is interested in keys that starts with "application", such as "applicationName", "application.port", etc.
-	 * <br />
+	 * <p>
 	 * If neither of {@code interestedKeys} and {@code interestedKeyPrefixes} is specified then the {@code listener} will be notified when whatever key is changed.
 	 * @return interested key-prefixed in the listener
 	 */


### PR DESCRIPTION
PR Type
Bugfix.

Fix javadoc `<br />` error, using `<p>` instead.