### PR TITLE
BeanFactoryUtils returns all beans including beans defined in ancestor bean factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - [Feature: zuul supports polaris router](https://github.com/Tencent/spring-cloud-tencent/pull/502)
 - [Refactor : optimize project and code](https://github.com/Tencent/spring-cloud-tencent/pull/506)
 - [Fix typo & Code optimization](https://github.com/Tencent/spring-cloud-tencent/pull/507)
+- [Bugfix：BeanFactoryUtils returns all beans including beans defined in ancestor bean factories](https://github.com/Tencent/spring-cloud-tencent/pull/515)

--- a/spring-cloud-tencent-commons/src/main/java/com/tencent/cloud/common/util/BeanFactoryUtils.java
+++ b/spring-cloud-tencent-commons/src/main/java/com/tencent/cloud/common/util/BeanFactoryUtils.java
@@ -24,7 +24,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+
+import static org.springframework.beans.factory.BeanFactoryUtils.beanNamesForTypeIncludingAncestors;
 
 /**
  * the utils for bean factory.
@@ -41,8 +44,7 @@ public final class BeanFactoryUtils {
 					.getName());
 		}
 
-		String[] beanNames = ((DefaultListableBeanFactory) beanFactory).getBeanNamesForType(requiredType);
-
+		String[] beanNames = beanNamesForTypeIncludingAncestors((ListableBeanFactory) beanFactory, requiredType);
 		if (beanNames.length == 0) {
 			return Collections.emptyList();
 		}

--- a/spring-cloud-tencent-commons/src/main/java/com/tencent/cloud/common/util/BeanFactoryUtils.java
+++ b/spring-cloud-tencent-commons/src/main/java/com/tencent/cloud/common/util/BeanFactoryUtils.java
@@ -18,15 +18,14 @@
 
 package com.tencent.cloud.common.util;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 
-import static org.springframework.beans.factory.BeanFactoryUtils.beanNamesForTypeIncludingAncestors;
+import static org.springframework.beans.factory.BeanFactoryUtils.beansOfTypeIncludingAncestors;
 
 /**
  * the utils for bean factory.
@@ -43,13 +42,7 @@ public final class BeanFactoryUtils {
 					.getName());
 		}
 
-		String[] beanNames = beanNamesForTypeIncludingAncestors((ListableBeanFactory) beanFactory, requiredType);
-		if (beanNames.length == 0) {
-			return Collections.emptyList();
-		}
-
-		return Arrays.stream(beanNames).map(
-				beanName -> beanFactory.getBean(beanName, requiredType)
-		).collect(Collectors.toList());
+		Map<String, T> beanMap = beansOfTypeIncludingAncestors((ListableBeanFactory) beanFactory, requiredType);
+		return new ArrayList<>(beanMap.values());
 	}
 }

--- a/spring-cloud-tencent-commons/src/main/java/com/tencent/cloud/common/util/BeanFactoryUtils.java
+++ b/spring-cloud-tencent-commons/src/main/java/com/tencent/cloud/common/util/BeanFactoryUtils.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 
 import static org.springframework.beans.factory.BeanFactoryUtils.beanNamesForTypeIncludingAncestors;
 
@@ -39,7 +38,7 @@ public final class BeanFactoryUtils {
 	}
 
 	public static <T> List<T> getBeans(BeanFactory beanFactory, Class<T> requiredType) {
-		if (!(beanFactory instanceof DefaultListableBeanFactory)) {
+		if (!(beanFactory instanceof ListableBeanFactory)) {
 			throw new RuntimeException("bean factory not support get list bean. factory type = " + beanFactory.getClass()
 					.getName());
 		}

--- a/spring-cloud-tencent-commons/src/test/java/com/tencent/cloud/common/util/BeanFactoryUtilsTest.java
+++ b/spring-cloud-tencent-commons/src/test/java/com/tencent/cloud/common/util/BeanFactoryUtilsTest.java
@@ -1,0 +1,30 @@
+package com.tencent.cloud.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+
+/**
+ * Test for {@link BeanFactoryUtils}.
+ *
+ * @author Derek Yi 2022-08-18
+ */
+public class BeanFactoryUtilsTest {
+
+	@Test
+	public void testGetBeansIncludingAncestors() {
+		DefaultListableBeanFactory parentBeanFactory = new DefaultListableBeanFactory();
+		parentBeanFactory.registerBeanDefinition("foo", new RootBeanDefinition(Foo.class));
+
+		DefaultListableBeanFactory childBeanFactory = new DefaultListableBeanFactory(parentBeanFactory);
+		Assert.assertTrue(childBeanFactory.getBeansOfType(Foo.class).isEmpty());
+
+		Assert.assertTrue(BeanFactoryUtils.getBeans(childBeanFactory, Foo.class).size() == 1);
+	}
+
+	static class Foo {
+
+	}
+}

--- a/spring-cloud-tencent-commons/src/test/java/com/tencent/cloud/common/util/BeanFactoryUtilsTest.java
+++ b/spring-cloud-tencent-commons/src/test/java/com/tencent/cloud/common/util/BeanFactoryUtilsTest.java
@@ -19,12 +19,18 @@ public class BeanFactoryUtilsTest {
 		parentBeanFactory.registerBeanDefinition("foo", new RootBeanDefinition(Foo.class));
 
 		DefaultListableBeanFactory childBeanFactory = new DefaultListableBeanFactory(parentBeanFactory);
-		Assert.assertTrue(childBeanFactory.getBeansOfType(Foo.class).isEmpty());
 
+		Assert.assertTrue(childBeanFactory.getBeansOfType(Foo.class).isEmpty());
 		Assert.assertTrue(BeanFactoryUtils.getBeans(childBeanFactory, Foo.class).size() == 1);
+
+		Assert.assertTrue(BeanFactoryUtils.getBeans(childBeanFactory, Bar.class).isEmpty());
 	}
 
 	static class Foo {
+
+	}
+
+	static class Bar {
 
 	}
 }


### PR DESCRIPTION
## PR Type

Bugfix

## Describe what this PR does for and how you did.

修复```PolarisLoadBalancerCompositeRuleBeanPostProcessor```获取不到父类容器的bean的问题。

原因和修复方案：```com.tencent.cloud.common.util.BeanFactoryUtils#getBeans```方法中使用的BeanFactory#getBeanNamesForType方法只返回本容器不包括父容器的bean名称，改用```org.springframework.beans.factory.BeanFactoryUtils#beansOfTypeIncludingAncestors```，该方法返回本容器及父容器中符合指定类型的所有的bean。

![image](https://user-images.githubusercontent.com/44155264/185402086-1123c271-4bd3-4f7e-968a-c43ff34c3ea1.png)

![微信图片_20220818210952](https://user-images.githubusercontent.com/44155264/185404122-20efd692-67dd-421d-a565-25e04c4740e5.jpg)

## Adding the issue link (#xxx) if possible.


## Note

## Checklist


- [x] Add copyright holder at the beginning of .class file if it is new.
- [x] Add information of this PR to CHANGELOG.md in root of project.
- [x] All junit tests passing.
- [x] Coverage from `Codecov Report` should not decrease.

## Checklist (Optional)

- [x] Will Pull Request to branch of 2020.0 and 2021.0.
- [x] Add documentation in javadoc in code or comment below the PR if necessary.
- [x] Add your name as @author to the beginning of .class file.

