### PR TITLE
Bugfix: InstancePreRegisteredEvent and InstanceRegisteredEvent modify Registration info

### DIFF
--- a/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/registry/PolarisRegistration.java
+++ b/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/registry/PolarisRegistration.java
@@ -19,7 +19,6 @@
 package com.tencent.cloud.polaris.registry;
 
 import java.net.URI;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,7 +36,7 @@ import org.springframework.util.CollectionUtils;
 /**
  * Registration object of Polaris.
  *
- * @author Haotian Zhang, Andrew Shan, Jie Cheng, Palmer.Xu
+ * @author Haotian Zhang, Andrew Shan, Jie Cheng, Palmer.Xu, changjin wei(魏昌进)
  */
 public class PolarisRegistration implements Registration {
 
@@ -55,7 +54,7 @@ public class PolarisRegistration implements Registration {
 
 	private Map<String, String> metadata;
 
-	private final String host;
+	private String host;
 
 	public PolarisRegistration(
 			PolarisDiscoveryProperties polarisDiscoveryProperties,
@@ -77,6 +76,10 @@ public class PolarisRegistration implements Registration {
 	@Override
 	public String getHost() {
 		return host;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
 	}
 
 	@Override
@@ -109,7 +112,7 @@ public class PolarisRegistration implements Registration {
 
 			instanceMetadata.putAll(staticMetadataManager.getMergedStaticMetadata());
 
-			this.metadata = Collections.unmodifiableMap(instanceMetadata);
+			this.metadata = instanceMetadata;
 		}
 		return metadata;
 	}


### PR DESCRIPTION
根据` Spring Cloud Commons`的设计可以利用`InstancePreRegisteredEvent`和`InstanceRegisteredEvent`对`Registration`进行一些相关骚操作, 比如`InstancePreRegisteredEvent`来修改`metadata`
`org.springframework.cloud.client.serviceregistry.AbstractAutoServiceRegistration#start()`
```java
	public void start() {
		if (!isEnabled()) {
			if (logger.isDebugEnabled()) {
				logger.debug("Discovery Lifecycle disabled. Not starting");
			}
			return;
		}

		// only initialize if nonSecurePort is greater than 0 and it isn't already running
		// because of containerPortInitializer below
		if (!this.running.get()) {
			this.context.publishEvent(
					new InstancePreRegisteredEvent(this, getRegistration()));
			register();
			if (shouldRegisterManagement()) {
				registerManagement();
			}
			this.context.publishEvent(
					new InstanceRegisteredEvent<>(this, getConfiguration()));
			this.running.compareAndSet(false, true);
		}

	}
```