### PR TITLE
feature: add config for customized local port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - [docs:prevent the release of the final version of the sdk.](https://github.com/Tencent/spring-cloud-tencent/pull/944)
 - [feat:support webclient and gateway report call metrics](https://github.com/Tencent/spring-cloud-tencent/pull/946)
 - [fix: fix nacos CircuitBreaker disable bug.](https://github.com/Tencent/spring-cloud-tencent/pull/949)
+- [feature: add config for customized local port.](https://github.com/Tencent/spring-cloud-tencent/pull/957)

--- a/spring-cloud-starter-tencent-polaris-config/src/main/java/com/tencent/cloud/polaris/config/configdata/PolarisConfigDataLocationResolver.java
+++ b/spring-cloud-starter-tencent-polaris-config/src/main/java/com/tencent/cloud/polaris/config/configdata/PolarisConfigDataLocationResolver.java
@@ -264,6 +264,8 @@ public class PolarisConfigDataLocationResolver implements
 		List<PolarisConfigModifier> modifierList = modifierList(polarisConfigProperties, polarisContextProperties);
 		return SDKContext.initContextByConfig(polarisContextProperties.configuration(modifierList, () -> {
 			return loadPolarisConfigProperties(resolverContext, String.class, "spring.cloud.client.ip-address");
+		}, () -> {
+			return loadPolarisConfigProperties(resolverContext, Integer.class, "spring.cloud.polaris.local-port");
 		}));
 	}
 

--- a/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/registry/PolarisRegistration.java
+++ b/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/registry/PolarisRegistration.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 
 import com.tencent.cloud.common.metadata.StaticMetadataManager;
 import com.tencent.cloud.polaris.PolarisDiscoveryProperties;
+import com.tencent.cloud.polaris.context.config.PolarisContextProperties;
 import com.tencent.cloud.polaris.extend.consul.ConsulContextProperties;
 import com.tencent.cloud.polaris.extend.nacos.NacosContextProperties;
 import com.tencent.polaris.client.api.SDKContext;
@@ -76,6 +77,7 @@ public class PolarisRegistration implements Registration {
 
 	public PolarisRegistration(
 			PolarisDiscoveryProperties polarisDiscoveryProperties,
+			@Nullable PolarisContextProperties polarisContextProperties,
 			@Nullable ConsulContextProperties consulContextProperties,
 			SDKContext context, StaticMetadataManager staticMetadataManager,
 			@Nullable NacosContextProperties nacosContextProperties,
@@ -89,6 +91,9 @@ public class PolarisRegistration implements Registration {
 		this.servletWebServerApplicationContext = servletWebServerApplicationContext;
 		this.reactiveWebServerApplicationContext = reactiveWebServerApplicationContext;
 		host = polarisContext.getConfig().getGlobal().getAPI().getBindIP();
+		if (polarisContextProperties != null) {
+			port = polarisContextProperties.getLocalPort();
+		}
 	}
 
 	@Override

--- a/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/registry/PolarisServiceRegistryAutoConfiguration.java
+++ b/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/registry/PolarisServiceRegistryAutoConfiguration.java
@@ -20,6 +20,7 @@ package com.tencent.cloud.polaris.registry;
 
 import com.tencent.cloud.common.metadata.StaticMetadataManager;
 import com.tencent.cloud.polaris.PolarisDiscoveryProperties;
+import com.tencent.cloud.polaris.context.config.PolarisContextProperties;
 import com.tencent.cloud.polaris.discovery.PolarisDiscoveryAutoConfiguration;
 import com.tencent.cloud.polaris.discovery.PolarisDiscoveryHandler;
 import com.tencent.cloud.polaris.extend.consul.ConsulContextProperties;
@@ -65,11 +66,12 @@ public class PolarisServiceRegistryAutoConfiguration {
 	@ConditionalOnBean(AutoServiceRegistrationProperties.class)
 	public PolarisRegistration polarisRegistration(
 			PolarisDiscoveryProperties polarisDiscoveryProperties,
+			PolarisContextProperties polarisContextProperties,
 			@Autowired(required = false) ConsulContextProperties consulContextProperties,
 			SDKContext context, StaticMetadataManager staticMetadataManager, NacosContextProperties nacosContextProperties,
 			@Autowired(required = false) ServletWebServerApplicationContext servletWebServerApplicationContext,
 			@Autowired(required = false) ReactiveWebServerApplicationContext reactiveWebServerApplicationContext) {
-		return new PolarisRegistration(polarisDiscoveryProperties, consulContextProperties, context,
+		return new PolarisRegistration(polarisDiscoveryProperties, polarisContextProperties, consulContextProperties, context,
 				staticMetadataManager, nacosContextProperties,
 				servletWebServerApplicationContext, reactiveWebServerApplicationContext);
 	}

--- a/spring-cloud-starter-tencent-polaris-discovery/src/test/java/com/tencent/cloud/polaris/registry/PolarisRegistrationTest.java
+++ b/spring-cloud-starter-tencent-polaris-discovery/src/test/java/com/tencent/cloud/polaris/registry/PolarisRegistrationTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import com.tencent.cloud.common.metadata.StaticMetadataManager;
 import com.tencent.cloud.polaris.PolarisDiscoveryProperties;
+import com.tencent.cloud.polaris.context.config.PolarisContextProperties;
 import com.tencent.cloud.polaris.extend.consul.ConsulContextProperties;
 import com.tencent.cloud.polaris.extend.nacos.NacosContextProperties;
 import com.tencent.polaris.api.config.Configuration;
@@ -62,6 +63,10 @@ public class PolarisRegistrationTest {
 
 	private PolarisRegistration polarisRegistration3;
 
+	private PolarisRegistration polarisRegistration4;
+
+	private static int testLocalPort = 10086;
+
 	@BeforeEach
 	void setUp() {
 		// mock PolarisDiscoveryProperties
@@ -70,23 +75,26 @@ public class PolarisRegistrationTest {
 		doReturn("http").when(polarisDiscoveryProperties).getProtocol();
 		doReturn(true).when(polarisDiscoveryProperties).isRegisterEnabled();
 
+		// mock PolarisContextProperties
+		PolarisContextProperties polarisContextProperties = mock(PolarisContextProperties.class);
+		doReturn(testLocalPort).when(polarisContextProperties).getLocalPort();
+
 		// mock ConsulContextProperties
 		ConsulContextProperties consulContextProperties = mock(ConsulContextProperties.class);
 		doReturn(true).when(consulContextProperties).isEnabled();
 		doReturn(true).when(consulContextProperties).isRegister();
 
 		// mock NacosContextProperties
-		nacosContextProperties = new NacosContextProperties();
-		nacosContextProperties.setEnabled(true);
-		nacosContextProperties.setRegisterEnabled(true);
-		nacosContextProperties.setContextPath("/");
-		nacosContextProperties.setClusterName("cluster");
-		nacosContextProperties.setGroup("");
-		nacosContextProperties.setDiscoveryEnabled(true);
-		nacosContextProperties.setPassword("");
-		nacosContextProperties.setUsername("");
-		nacosContextProperties.setServerAddr("");
-		nacosContextProperties.toString();
+		nacosContextProperties = mock(NacosContextProperties.class);
+		doReturn(true).when(nacosContextProperties).isEnabled();
+		doReturn(true).when(nacosContextProperties).isRegisterEnabled();
+		doReturn("/").when(nacosContextProperties).getContextPath();
+		doReturn("cluster").when(nacosContextProperties).getClusterName();
+		doReturn("").when(nacosContextProperties).getGroup();
+		doReturn(true).when(nacosContextProperties).isDiscoveryEnabled();
+		doReturn("").when(nacosContextProperties).getPassword();
+		doReturn("").when(nacosContextProperties).getUsername();
+		doReturn("").when(nacosContextProperties).getServerAddr();
 
 		// mock SDKContext
 		APIConfig apiConfig = mock(APIConfig.class);
@@ -114,15 +122,19 @@ public class PolarisRegistrationTest {
 		ReactiveWebServerApplicationContext reactiveWebServerApplicationContext = mock(ReactiveWebServerApplicationContext.class);
 		doReturn(reactiveWebServer).when(reactiveWebServerApplicationContext).getWebServer();
 
-		polarisRegistration1 = new PolarisRegistration(polarisDiscoveryProperties, consulContextProperties,
+		polarisRegistration1 = new PolarisRegistration(polarisDiscoveryProperties, null, consulContextProperties,
 				polarisContext, staticMetadataManager, nacosContextProperties,
 				servletWebServerApplicationContext, null);
 
-		polarisRegistration2 = new PolarisRegistration(polarisDiscoveryProperties, consulContextProperties,
+		polarisRegistration2 = new PolarisRegistration(polarisDiscoveryProperties, null, consulContextProperties,
 				polarisContext, staticMetadataManager, nacosContextProperties,
 				null, reactiveWebServerApplicationContext);
 
-		polarisRegistration3 = new PolarisRegistration(polarisDiscoveryProperties, consulContextProperties,
+		polarisRegistration3 = new PolarisRegistration(polarisDiscoveryProperties, null, consulContextProperties,
+				polarisContext, staticMetadataManager, nacosContextProperties,
+				null, null);
+
+		polarisRegistration4 = new PolarisRegistration(polarisDiscoveryProperties, polarisContextProperties, consulContextProperties,
 				polarisContext, staticMetadataManager, nacosContextProperties,
 				null, null);
 	}
@@ -147,6 +159,7 @@ public class PolarisRegistrationTest {
 		catch (RuntimeException e) {
 			assertThat(e.getMessage()).isEqualTo("Unsupported web type.");
 		}
+		assertThat(polarisRegistration4.getPort()).isEqualTo(testLocalPort);
 	}
 
 	@Test

--- a/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/config/PolarisContextAutoConfiguration.java
+++ b/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/config/PolarisContextAutoConfiguration.java
@@ -51,6 +51,8 @@ public class PolarisContextAutoConfiguration {
 	public SDKContext polarisContext(PolarisContextProperties properties, Environment environment, List<PolarisConfigModifier> modifierList) throws PolarisException {
 		return SDKContext.initContextByConfig(properties.configuration(modifierList, () -> {
 			return environment.getProperty("spring.cloud.client.ip-address");
+		}, () -> {
+			return environment.getProperty("spring.cloud.polaris.local-port", Integer.class, 0);
 		}));
 	}
 

--- a/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/config/PolarisContextProperties.java
+++ b/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/config/PolarisContextProperties.java
@@ -53,6 +53,11 @@ public class PolarisContextProperties {
 	private String localIpAddress;
 
 	/**
+	 * current server local port.
+	 */
+	private Integer localPort;
+
+	/**
 	 * If polaris enabled.
 	 */
 	private Boolean enabled;
@@ -67,7 +72,7 @@ public class PolarisContextProperties {
 	 */
 	private String service;
 
-	public Configuration configuration(List<PolarisConfigModifier> modifierList, Supplier<String> ipAddressSupplier) {
+	public Configuration configuration(List<PolarisConfigModifier> modifierList, Supplier<String> ipAddressSupplier, Supplier<Integer> portSupplier) {
 		// 1. Read user-defined polaris.yml configuration
 		ConfigurationImpl configuration = (ConfigurationImpl) ConfigAPIFactory
 				.defaultConfig(ConfigProvider.DEFAULT_CONFIG);
@@ -77,6 +82,9 @@ public class PolarisContextProperties {
 		if (StringUtils.isBlank(localIpAddress)) {
 			defaultHost = ipAddressSupplier.get();
 			this.localIpAddress = defaultHost;
+		}
+		if (this.localPort == null || this.localPort <= 0) {
+			this.localPort = portSupplier.get();
 		}
 
 		configuration.getGlobal().getAPI().setBindIP(defaultHost);
@@ -108,6 +116,14 @@ public class PolarisContextProperties {
 
 	public void setLocalIpAddress(String localIpAddress) {
 		this.localIpAddress = localIpAddress;
+	}
+
+	public Integer getLocalPort() {
+		return localPort;
+	}
+
+	public void setLocalPort(Integer localPort) {
+		this.localPort = localPort;
 	}
 
 	public Boolean getEnabled() {


### PR DESCRIPTION
the key is `spring.cloud.polaris.local-port`

## PR Type

Feature. Close issue #849 

## Describe what this PR does for and how you did.

Add a config `spring.cloud.client.port` and prefer it when user specified.

## Adding the issue link (#xxx) if possible.

fixes #849 

## Note

## Checklist

- [x] Add information of this PR to CHANGELOG.md in root of project.
- [x] Add documentation in javadoc or comment below the PR if necessary.

## Checklist (Optional)

- [ ] Will pull request to branch of 2020.0.
- [x] Will pull request to branch of 2022.0.
