### PR TITLE
fix: move the RemoteConfigFileRepo destroy hook to the Polaris config module

### DIFF
--- a/spring-cloud-starter-tencent-polaris-config/src/main/java/com/tencent/cloud/polaris/config/PolarisConfigAutoConfiguration.java
+++ b/spring-cloud-starter-tencent-polaris-config/src/main/java/com/tencent/cloud/polaris/config/PolarisConfigAutoConfiguration.java
@@ -27,12 +27,14 @@ import com.tencent.cloud.polaris.config.adapter.PolarisRefreshEntireContextRefre
 import com.tencent.cloud.polaris.config.annotation.PolarisConfigAnnotationProcessor;
 import com.tencent.cloud.polaris.config.condition.ConditionalOnReflectRefreshType;
 import com.tencent.cloud.polaris.config.config.PolarisConfigProperties;
+import com.tencent.cloud.polaris.config.listener.PolarisConfigApplicationEventListener;
 import com.tencent.cloud.polaris.config.listener.PolarisConfigChangeEventListener;
 import com.tencent.cloud.polaris.config.listener.PolarisConfigRefreshOptimizationListener;
 import com.tencent.cloud.polaris.config.logger.PolarisConfigLoggerApplicationListener;
 import com.tencent.cloud.polaris.config.spring.annotation.SpringValueProcessor;
 import com.tencent.cloud.polaris.config.spring.property.PlaceholderHelper;
 import com.tencent.cloud.polaris.config.spring.property.SpringValueRegistry;
+import com.tencent.cloud.polaris.context.PolarisSDKContextManager;
 
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -119,6 +121,11 @@ public class PolarisConfigAutoConfiguration {
 		@Bean
 		public PolarisConfigRefreshOptimizationListener polarisConfigRefreshOptimizationListener() {
 			return new PolarisConfigRefreshOptimizationListener();
+		}
+
+		@Bean
+		public PolarisConfigApplicationEventListener polarisContextApplicationEventListener(PolarisSDKContextManager polarisSDKContextManager) {
+			return new PolarisConfigApplicationEventListener(polarisSDKContextManager);
 		}
 	}
 }

--- a/spring-cloud-starter-tencent-polaris-config/src/main/java/com/tencent/cloud/polaris/config/listener/PolarisConfigApplicationEventListener.java
+++ b/spring-cloud-starter-tencent-polaris-config/src/main/java/com/tencent/cloud/polaris/config/listener/PolarisConfigApplicationEventListener.java
@@ -16,7 +16,7 @@
  *
  */
 
-package com.tencent.cloud.polaris.context.listener;
+package com.tencent.cloud.polaris.config.listener;
 
 import com.tencent.cloud.polaris.context.PolarisSDKContextManager;
 import com.tencent.polaris.configuration.client.internal.RemoteConfigFileRepo;
@@ -33,11 +33,11 @@ import org.springframework.lang.NonNull;
  * @author shuiqingliu
  * @since 2023/8/29
  **/
-public class PolarisContextApplicationEventListener implements ApplicationListener<ApplicationEvent> {
+public class PolarisConfigApplicationEventListener implements ApplicationListener<ApplicationEvent> {
 
 	private final PolarisSDKContextManager polarisSDKContextManager;
 
-	public PolarisContextApplicationEventListener(PolarisSDKContextManager polarisSDKContextManager) {
+	public PolarisConfigApplicationEventListener(PolarisSDKContextManager polarisSDKContextManager) {
 		this.polarisSDKContextManager = polarisSDKContextManager;
 	}
 

--- a/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/config/PolarisContextAutoConfiguration.java
+++ b/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/config/PolarisContextAutoConfiguration.java
@@ -25,7 +25,6 @@ import com.tencent.cloud.polaris.context.ModifyAddress;
 import com.tencent.cloud.polaris.context.PolarisConfigModifier;
 import com.tencent.cloud.polaris.context.PolarisSDKContextManager;
 import com.tencent.cloud.polaris.context.ServiceRuleManager;
-import com.tencent.cloud.polaris.context.listener.PolarisContextApplicationEventListener;
 import com.tencent.polaris.api.exception.PolarisException;
 import com.tencent.polaris.client.api.SDKContext;
 
@@ -58,10 +57,5 @@ public class PolarisContextAutoConfiguration {
 	@Bean
 	public ServiceRuleManager serviceRuleManager(PolarisSDKContextManager polarisSDKContextManager) {
 		return new ServiceRuleManager(polarisSDKContextManager.getSDKContext(), polarisSDKContextManager.getConsumerAPI());
-	}
-
-	@Bean
-	public PolarisContextApplicationEventListener polarisContextApplicationEventListener(PolarisSDKContextManager polarisSDKContextManager) {
-		return new PolarisContextApplicationEventListener(polarisSDKContextManager);
 	}
 }


### PR DESCRIPTION
## PR Type
Bugfix
<!--
Bugfix.
Feature.
Code style update (formatting, local variables).
Refactoring (no functional changes, no api changes).
Documentation content changes.
Other... Please describe:
 -->

## Describe what this PR does for and how you did.
RemoteConfigFileRepo hook can only register in Polaris config module

## Adding the issue link (#xxx) if possible.

<!--
fixes #
 -->

## Note

## Checklist

- [ ] Add information of this PR to CHANGELOG.md in root of project.
- [x] Add documentation in javadoc or comment below the PR if necessary.

## Checklist (Optional)

- [x] Will pull request to branch of 2020.0.
- [x] Will pull request to branch of 2022.0.
