### PR TITLE
fix: change the timing of sdk context destruction.

### DIFF
--- a/spring-cloud-starter-tencent-polaris-config/src/main/java/com/tencent/cloud/polaris/config/PolarisConfigAutoConfiguration.java
+++ b/spring-cloud-starter-tencent-polaris-config/src/main/java/com/tencent/cloud/polaris/config/PolarisConfigAutoConfiguration.java
@@ -27,14 +27,12 @@ import com.tencent.cloud.polaris.config.adapter.PolarisRefreshEntireContextRefre
 import com.tencent.cloud.polaris.config.annotation.PolarisConfigAnnotationProcessor;
 import com.tencent.cloud.polaris.config.condition.ConditionalOnReflectRefreshType;
 import com.tencent.cloud.polaris.config.config.PolarisConfigProperties;
-import com.tencent.cloud.polaris.config.listener.PolarisConfigApplicationEventListener;
 import com.tencent.cloud.polaris.config.listener.PolarisConfigChangeEventListener;
 import com.tencent.cloud.polaris.config.listener.PolarisConfigRefreshOptimizationListener;
 import com.tencent.cloud.polaris.config.logger.PolarisConfigLoggerApplicationListener;
 import com.tencent.cloud.polaris.config.spring.annotation.SpringValueProcessor;
 import com.tencent.cloud.polaris.config.spring.property.PlaceholderHelper;
 import com.tencent.cloud.polaris.config.spring.property.SpringValueRegistry;
-import com.tencent.cloud.polaris.context.PolarisSDKContextManager;
 
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -121,11 +119,6 @@ public class PolarisConfigAutoConfiguration {
 		@Bean
 		public PolarisConfigRefreshOptimizationListener polarisConfigRefreshOptimizationListener() {
 			return new PolarisConfigRefreshOptimizationListener();
-		}
-
-		@Bean
-		public PolarisConfigApplicationEventListener polarisContextApplicationEventListener(PolarisSDKContextManager polarisSDKContextManager) {
-			return new PolarisConfigApplicationEventListener(polarisSDKContextManager);
 		}
 	}
 }

--- a/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/config/PolarisContextAutoConfiguration.java
+++ b/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/config/PolarisContextAutoConfiguration.java
@@ -25,6 +25,7 @@ import com.tencent.cloud.polaris.context.ModifyAddress;
 import com.tencent.cloud.polaris.context.PolarisConfigModifier;
 import com.tencent.cloud.polaris.context.PolarisSDKContextManager;
 import com.tencent.cloud.polaris.context.ServiceRuleManager;
+import com.tencent.cloud.polaris.context.listener.PolarisContextApplicationEventListener;
 import com.tencent.polaris.api.exception.PolarisException;
 import com.tencent.polaris.client.api.SDKContext;
 
@@ -57,5 +58,10 @@ public class PolarisContextAutoConfiguration {
 	@Bean
 	public ServiceRuleManager serviceRuleManager(PolarisSDKContextManager polarisSDKContextManager) {
 		return new ServiceRuleManager(polarisSDKContextManager.getSDKContext(), polarisSDKContextManager.getConsumerAPI());
+	}
+
+	@Bean
+	public PolarisContextApplicationEventListener contextApplicationEventListener(PolarisSDKContextManager polarisSDKContextManager) {
+		return new PolarisContextApplicationEventListener(polarisSDKContextManager);
 	}
 }

--- a/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/listener/PolarisContextApplicationEventListener.java
+++ b/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/listener/PolarisContextApplicationEventListener.java
@@ -16,42 +16,33 @@
  *
  */
 
-package com.tencent.cloud.polaris.config.listener;
+package com.tencent.cloud.polaris.context.listener;
 
 import com.tencent.cloud.polaris.context.PolarisSDKContextManager;
-import com.tencent.polaris.configuration.client.internal.RemoteConfigFileRepo;
 
 import org.springframework.boot.context.event.ApplicationFailedEvent;
-import org.springframework.boot.context.event.ApplicationPreparedEvent;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.lang.NonNull;
 
-/*
- * Polaris config non-daemon thread stop listener
- *
- * @author shuiqingliu
- * @since 2023/8/29
+/**
+ * @author frankjlli
+ * @since 2023/9/18
  **/
-public class PolarisConfigApplicationEventListener implements ApplicationListener<ApplicationEvent> {
+
+public class PolarisContextApplicationEventListener implements ApplicationListener<ApplicationEvent> {
 
 	private final PolarisSDKContextManager polarisSDKContextManager;
 
-	public PolarisConfigApplicationEventListener(PolarisSDKContextManager polarisSDKContextManager) {
+	public PolarisContextApplicationEventListener(PolarisSDKContextManager polarisSDKContextManager) {
 		this.polarisSDKContextManager = polarisSDKContextManager;
 	}
 
 	@Override
 	public void onApplicationEvent(@NonNull ApplicationEvent event) {
-		if (event instanceof ApplicationPreparedEvent) {
-			RemoteConfigFileRepo.registerRepoDestroyHook(polarisSDKContextManager.getSDKContext());
-		}
-
 		if (event instanceof ApplicationFailedEvent) {
-			RemoteConfigFileRepo.registerRepoDestroyHook(polarisSDKContextManager.getSDKContext());
 			//implicit invoke 'destroy' when the spring application fails to start, in order to stop non-daemon threads.
 			polarisSDKContextManager.getSDKContext().destroy();
 		}
 	}
-
 }


### PR DESCRIPTION
## PR Type
Bugfix
<!--
Bugfix.
Feature.
Code style update (formatting, local variables).
Refactoring (no functional changes, no api changes).
Documentation content changes.
Other... Please describe:
 -->

## Describe what this PR does for and how you did.
Move the SDK context destroy invocation from Polaris config to Polaris context in order to complete context destruction
## Adding the issue link (#xxx) if possible.

<!--
fixes #
 -->

## Note

## Checklist

- [ ] Add information of this PR to CHANGELOG.md in root of project.
- [x] Add documentation in javadoc or comment below the PR if necessary.

## Checklist (Optional)

- [x] Will pull request to branch of 2020.0.
- [x] Will pull request to branch of 2022.0.
