### PR TITLE
refactor:optimize the order and condition matching of service registration automatic configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 - [fix:the polaris config relation non-daemon thread should stop when application fails to start.](https://github.com/Tencent/spring-cloud-tencent/pull/1101)
 - [Refactoring:remove invalid @AutoConfigureAfter and @AutoConfigureBefore from discovery client automatic configuration.](https://github.com/Tencent/spring-cloud-tencent/pull/1117)
 - [fix:fix feign url bug when using sleuth.](https://github.com/Tencent/spring-cloud-tencent/pull/1121)
-- [refactor:optimize the order and condition matching of service registration automatic configuration.](https://github.com/Tencent/spring-cloud-tencent/pull/1129)
+- [refactor:optimize the order and condition matching of service registration automatic configuration.](https://github.com/Tencent/spring-cloud-tencent/pull/1132)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - [fix:the polaris config relation non-daemon thread should stop when application fails to start.](https://github.com/Tencent/spring-cloud-tencent/pull/1101)
 - [Refactoring:remove invalid @AutoConfigureAfter and @AutoConfigureBefore from discovery client automatic configuration.](https://github.com/Tencent/spring-cloud-tencent/pull/1117)
 - [fix:fix feign url bug when using sleuth.](https://github.com/Tencent/spring-cloud-tencent/pull/1121)
+- [refactor:optimize the order and condition matching of service registration automatic configuration.](https://github.com/Tencent/spring-cloud-tencent/pull/1129)

--- a/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/registry/PolarisServiceRegistryAutoConfiguration.java
+++ b/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/registry/PolarisServiceRegistryAutoConfiguration.java
@@ -31,14 +31,14 @@ import com.tencent.cloud.rpc.enhancement.stat.config.PolarisStatProperties;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.reactive.context.ReactiveWebServerApplicationContext;
 import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationAutoConfiguration;
-import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
+import org.springframework.cloud.client.serviceregistry.ServiceRegistryAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -49,10 +49,10 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties
+@ConditionalOnBean(AutoServiceRegistrationProperties.class)
 @ConditionalOnPolarisRegisterEnabled
-@ConditionalOnProperty(value = "spring.cloud.service-registry.auto-registration.enabled", matchIfMissing = true)
-@AutoConfigureAfter({AutoServiceRegistrationConfiguration.class, AutoServiceRegistrationAutoConfiguration.class,
-		PolarisDiscoveryAutoConfiguration.class})
+@AutoConfigureBefore(ServiceRegistryAutoConfiguration.class)
+@AutoConfigureAfter({AutoServiceRegistrationAutoConfiguration.class, PolarisDiscoveryAutoConfiguration.class})
 public class PolarisServiceRegistryAutoConfiguration {
 
 	@Bean
@@ -65,7 +65,6 @@ public class PolarisServiceRegistryAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnBean(AutoServiceRegistrationProperties.class)
 	public PolarisRegistration polarisRegistration(
 			PolarisDiscoveryProperties polarisDiscoveryProperties,
 			PolarisContextProperties polarisContextProperties,
@@ -81,7 +80,6 @@ public class PolarisServiceRegistryAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnBean(AutoServiceRegistrationProperties.class)
 	public PolarisAutoServiceRegistration polarisAutoServiceRegistration(
 			PolarisServiceRegistry registry,
 			AutoServiceRegistrationProperties autoServiceRegistrationProperties,


### PR DESCRIPTION
## PR Type

Refactoring (no functional changes, no api changes).

## Describe what this PR does for and how you did.

服务注册自动配置有下面几个疑问：

1. @AutoConfigureAfter 中 AutoServiceRegistrationConfiguration.class 应该是无效的。解决：移除这个参数
2. PolarisServiceRegistry 定义需要在 ServiceRegistryAutoConfiguration 完成前执行。解决：添加 @AutoConfigureBefore
3. 判断是否进行注册服务的条件注解放在服务注册自动配置类上覆盖所有 bean 会更清晰？

## Adding the issue link (#xxx) if possible.

## Note

## Checklist

- [ ] Add information of this PR to CHANGELOG.md in root of project.
- [ ] Add documentation in javadoc or comment below the PR if necessary.

## Checklist (Optional)

- [ ] Will pull request to branch of 2020.0.
- [ ] Will pull request to branch of 2022.0.
