### PR TITLE
fix: fix the logging problem open at #1189.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 ---
 
+- [fix: fix the logging problem open at #1189.](https://github.com/Tencent/spring-cloud-tencent/pull/1196)
 - [fix:the polaris config relation non-daemon thread should stop when application fails to start.](https://github.com/Tencent/spring-cloud-tencent/pull/1102)
 - [Refactoring:remove invalid @AutoConfigureAfter and @AutoConfigureBefore from discovery client automatic configuration.](https://github.com/Tencent/spring-cloud-tencent/pull/1116)
 - [fix:fix feign url bug when using sleuth.](https://github.com/Tencent/spring-cloud-tencent/pull/1120)

--- a/spring-cloud-starter-tencent-polaris-config/src/main/java/com/tencent/cloud/polaris/config/logger/PolarisConfigLoggerApplicationListener.java
+++ b/spring-cloud-starter-tencent-polaris-config/src/main/java/com/tencent/cloud/polaris/config/logger/PolarisConfigLoggerApplicationListener.java
@@ -17,6 +17,7 @@
  */
 package com.tencent.cloud.polaris.config.logger;
 
+import com.tencent.polaris.logging.PolarisLogging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +44,7 @@ public class PolarisConfigLoggerApplicationListener implements ApplicationListen
 				LoggingSystem loggingSystem = LoggingSystem.get(classLoader);
 				LOGGER.info("PolarisConfigLoggerApplicationListener onApplicationEvent init loggingSystem:{}", loggingSystem);
 				PolarisConfigLoggerContext.setLogSystem(loggingSystem);
+				PolarisLogging.getInstance().loadConfiguration();
 			}
 		}
 		catch (Exception e) {


### PR DESCRIPTION
利用logging.level.xx.xx=trace配置日志级别时，北极星日志配置失效。polaris-java的日志都打印在控制台。
通过在 PolarisConfigLoggerApplicationListener 加上 PolarisLogging.getInstance().loadConfiguration(); 后，可以避免 Polaris 的配置失效，这时候用户配置的内容不会影响北极星日志


fixes #1189 


## Note

## Checklist

- [ ✅] Add information of this PR to CHANGELOG.md in root of project.

## Checklist (Optional)

- [✅ ] Will pull request to branch of 2020.0.
- [✅ ] Will pull request to branch of 2022.0.
- [ ✅] Will pull request to branch of hoxton.
