### PR TITLE
修复  restTemplateCustomizer bean 冲突导致服务无法正常启动 问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Change Log
 ---
-- [fix: Fix restTemplateCustomizer bean conflict causing service to fail to start properly at #1229.](https://github.com/Tencent/spring-cloud-tencent/pull/1233)
+
+- [fix: Fix restTemplateCustomizer bean conflict causing service to fail to start properly at #1229.](https://github.com/Tencent/spring-cloud-tencent/pull/1234)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Change Log
 ---
+- [fix: Fix restTemplateCustomizer bean conflict causing service to fail to start properly at #1229.](https://github.com/Tencent/spring-cloud-tencent/pull/1233)
 

--- a/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/loadbalancer/PolarisLoadBalancerAutoConfiguration.java
+++ b/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/loadbalancer/PolarisLoadBalancerAutoConfiguration.java
@@ -52,7 +52,7 @@ import org.springframework.http.client.ClientHttpRequestInterceptor;
 public class PolarisLoadBalancerAutoConfiguration {
 
 	@Bean
-	public RestTemplateCustomizer restTemplateCustomizer(
+	public RestTemplateCustomizer polarisRestTemplateCustomizer(
 			@Autowired(required = false) RetryLoadBalancerInterceptor retryLoadBalancerInterceptor,
 			@Autowired(required = false) LoadBalancerInterceptor loadBalancerInterceptor) {
 		return restTemplate -> {


### PR DESCRIPTION
修复  restTemplateCustomizer bean 冲突导致服务无法正常启动 问题 fix: #1229 

说明：

Spring 生态的中的 Customizer 扩展配置的方式，一定要注意 Bean 的命名。
- 要么在 @Bean 注解中手动指定名称
- 要么修改 Bean 定义的方法名

来保证 Customizer Bean 不会冲突。
