### PR TITLE
修复 restTemplateCustomizer bean 冲突导致服务无法正常启动 问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Change Log
 ---
-
+- [fix: Fix restTemplateCustomizer bean conflict causing service to fail to start properly at #1229.](https://github.com/Tencent/spring-cloud-tencent/pull/1236)

--- a/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/loadbalancer/PolarisLoadBalancerAutoConfiguration.java
+++ b/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/loadbalancer/PolarisLoadBalancerAutoConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.loadbalancer.config.LoadBalancerAutoConfigurati
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Auto-configuration of loadbalancer for Polaris.
@@ -58,17 +59,32 @@ public class PolarisLoadBalancerAutoConfiguration {
 		return restTemplate -> {
 			List<ClientHttpRequestInterceptor> list = new ArrayList<>(restTemplate.getInterceptors());
 			// LoadBalancerInterceptor must invoke before EnhancedRestTemplateInterceptor
-			if (retryLoadBalancerInterceptor != null || loadBalancerInterceptor != null) {
-				int addIndex = list.size();
+			int addIndex = list.size();
+			if (CollectionUtils.containsInstance(list, retryLoadBalancerInterceptor) || CollectionUtils.containsInstance(list, loadBalancerInterceptor)) {
+				ClientHttpRequestInterceptor enhancedRestTemplateInterceptor = null;
 				for (int i = 0; i < list.size(); i++) {
 					if (list.get(i) instanceof EnhancedRestTemplateInterceptor) {
+						enhancedRestTemplateInterceptor = list.get(i);
 						addIndex = i;
 					}
 				}
-				list.add(addIndex,
-						retryLoadBalancerInterceptor != null
-								? retryLoadBalancerInterceptor
-								: loadBalancerInterceptor);
+				if (enhancedRestTemplateInterceptor != null) {
+					list.remove(addIndex);
+					list.add(enhancedRestTemplateInterceptor);
+				}
+			}
+			else {
+				if (retryLoadBalancerInterceptor != null || loadBalancerInterceptor != null) {
+					for (int i = 0; i < list.size(); i++) {
+						if (list.get(i) instanceof EnhancedRestTemplateInterceptor) {
+							addIndex = i;
+						}
+					}
+					list.add(addIndex,
+							retryLoadBalancerInterceptor != null
+									? retryLoadBalancerInterceptor
+									: loadBalancerInterceptor);
+				}
 			}
 			restTemplate.setInterceptors(list);
 		};

--- a/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/loadbalancer/PolarisLoadBalancerAutoConfiguration.java
+++ b/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/loadbalancer/PolarisLoadBalancerAutoConfiguration.java
@@ -52,7 +52,7 @@ import org.springframework.http.client.ClientHttpRequestInterceptor;
 public class PolarisLoadBalancerAutoConfiguration {
 
 	@Bean
-	public RestTemplateCustomizer restTemplateCustomizer(
+	public RestTemplateCustomizer polarisRestTemplateCustomizer(
 			@Autowired(required = false) RetryLoadBalancerInterceptor retryLoadBalancerInterceptor,
 			@Autowired(required = false) LoadBalancerInterceptor loadBalancerInterceptor) {
 		return restTemplate -> {


### PR DESCRIPTION
修复 restTemplateCustomizer bean 冲突导致服务无法正常启动 问题 fix: https://github.com/Tencent/spring-cloud-tencent/issues/1229

说明：

Spring 生态的中的 Customizer 扩展配置的方式，一定要注意 Bean 的命名。

要么在 @bean 注解中手动指定名称
要么修改 Bean 定义的方法名
来保证 Customizer Bean 不会冲突。