### PR TITLE
fix:fix restTemplateCustomizer bean conflict causing service to fail to start properly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@
 - [fix:fix rule-based router when using RestTemplate.](https://github.com/Tencent/spring-cloud-tencent/pull/1202)
 - [fix:fix sct-all wrong spring boot version obtain.](https://github.com/Tencent/spring-cloud-tencent/pull/1206)
 - [fix:fix reporter wrong initialization when using config data.](https://github.com/Tencent/spring-cloud-tencent/pull/1220)
+- [fix:fix restTemplateCustomizer bean conflict causing service to fail to start properly at #1229.](https://github.com/Tencent/spring-cloud-tencent/pull/1237)

--- a/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/loadbalancer/PolarisLoadBalancerAutoConfiguration.java
+++ b/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/loadbalancer/PolarisLoadBalancerAutoConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.loadbalancer.config.LoadBalancerAutoConfigurati
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Auto-configuration of loadbalancer for Polaris.
@@ -58,17 +59,32 @@ public class PolarisLoadBalancerAutoConfiguration {
 		return restTemplate -> {
 			List<ClientHttpRequestInterceptor> list = new ArrayList<>(restTemplate.getInterceptors());
 			// LoadBalancerInterceptor must invoke before EnhancedRestTemplateInterceptor
-			if (retryLoadBalancerInterceptor != null || loadBalancerInterceptor != null) {
-				int addIndex = list.size();
+			int addIndex = list.size();
+			if (CollectionUtils.containsInstance(list, retryLoadBalancerInterceptor) || CollectionUtils.containsInstance(list, loadBalancerInterceptor)) {
+				ClientHttpRequestInterceptor enhancedRestTemplateInterceptor = null;
 				for (int i = 0; i < list.size(); i++) {
 					if (list.get(i) instanceof EnhancedRestTemplateInterceptor) {
+						enhancedRestTemplateInterceptor = list.get(i);
 						addIndex = i;
 					}
 				}
-				list.add(addIndex,
-						retryLoadBalancerInterceptor != null
-								? retryLoadBalancerInterceptor
-								: loadBalancerInterceptor);
+				if (enhancedRestTemplateInterceptor != null) {
+					list.remove(addIndex);
+					list.add(enhancedRestTemplateInterceptor);
+				}
+			}
+			else {
+				if (retryLoadBalancerInterceptor != null || loadBalancerInterceptor != null) {
+					for (int i = 0; i < list.size(); i++) {
+						if (list.get(i) instanceof EnhancedRestTemplateInterceptor) {
+							addIndex = i;
+						}
+					}
+					list.add(addIndex,
+							retryLoadBalancerInterceptor != null
+									? retryLoadBalancerInterceptor
+									: loadBalancerInterceptor);
+				}
 			}
 			restTemplate.setInterceptors(list);
 		};

--- a/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/loadbalancer/PolarisLoadBalancerAutoConfiguration.java
+++ b/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/loadbalancer/PolarisLoadBalancerAutoConfiguration.java
@@ -53,7 +53,7 @@ import org.springframework.util.CollectionUtils;
 public class PolarisLoadBalancerAutoConfiguration {
 
 	@Bean
-	public RestTemplateCustomizer restTemplateCustomizer(
+	public RestTemplateCustomizer polarisRestTemplateCustomizer(
 			@Autowired(required = false) RetryLoadBalancerInterceptor retryLoadBalancerInterceptor,
 			@Autowired(required = false) LoadBalancerInterceptor loadBalancerInterceptor) {
 		return restTemplate -> {


### PR DESCRIPTION
修复 restTemplateCustomizer bean 冲突导致服务无法正常启动 fix #1229

## PR Type

Bugfix.

## Describe what this PR does for and how you did.

## Adding the issue link (#xxx) if possible.

fixes #1229 

## Note

## Checklist

- [ ] Add information of this PR to CHANGELOG.md in root of project.
- [ ] Add documentation in javadoc or comment below the PR if necessary.

## Checklist (Optional)

- [ ] Will pull request to branch of 2023.0.
- [ ] Will pull request to branch of 2022.0.
- [ ] Will pull request to branch of 2020.0.
- [ ] Will pull request to branch of hoxton.
