### PR TITLE
fix: fix the lossless provider override in multiple registries scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - [feat: support lossless online and offline](https://github.com/Tencent/spring-cloud-tencent/pull/1268)
 - [feat: support lane router](https://github.com/Tencent/spring-cloud-tencent/pull/1269)
 - [feat: add lane router examples](https://github.com/Tencent/spring-cloud-tencent/pull/1270)
+- [fix: fix the lossless provider override in multiple registries scenario](https://github.com/Tencent/spring-cloud-tencent/pull/1271)

--- a/spring-cloud-tencent-plugin-starters/spring-cloud-starter-tencent-discovery-adapter-plugin/src/main/java/com/tencent/cloud/plugin/discovery/adapter/transformer/NacosRegistrationTransformer.java
+++ b/spring-cloud-tencent-plugin-starters/spring-cloud-starter-tencent-discovery-adapter-plugin/src/main/java/com/tencent/cloud/plugin/discovery/adapter/transformer/NacosRegistrationTransformer.java
@@ -29,6 +29,11 @@ import org.springframework.cloud.client.serviceregistry.Registration;
 public class NacosRegistrationTransformer implements RegistrationTransformer {
 
 	@Override
+	public String getRegistry() {
+		return "nacos";
+	}
+
+	@Override
 	public void transformCustom(DefaultInstance instance, Registration registration) {
 		if (registration instanceof NacosRegistration nacosRegistration) {
 			NacosDiscoveryProperties nacosDiscoveryProperties = nacosRegistration.getNacosDiscoveryProperties();

--- a/spring-cloud-tencent-rpc-enhancement/src/main/java/com/tencent/cloud/rpc/enhancement/transformer/PolarisRegistrationTransformer.java
+++ b/spring-cloud-tencent-rpc-enhancement/src/main/java/com/tencent/cloud/rpc/enhancement/transformer/PolarisRegistrationTransformer.java
@@ -20,6 +20,8 @@ package com.tencent.cloud.rpc.enhancement.transformer;
 
 public class PolarisRegistrationTransformer implements RegistrationTransformer {
 
-
-
+	@Override
+	public String getRegistry() {
+		return "polaris";
+	}
 }

--- a/spring-cloud-tencent-rpc-enhancement/src/main/java/com/tencent/cloud/rpc/enhancement/transformer/RegistrationTransformer.java
+++ b/spring-cloud-tencent-rpc-enhancement/src/main/java/com/tencent/cloud/rpc/enhancement/transformer/RegistrationTransformer.java
@@ -32,6 +32,8 @@ import org.springframework.cloud.client.serviceregistry.Registration;
  */
 public interface RegistrationTransformer {
 
+	String getRegistry();
+
 	default Instance transform(Registration registration) {
 		DefaultInstance instance = new DefaultInstance();
 		transformDefault(instance, registration);
@@ -40,6 +42,7 @@ public interface RegistrationTransformer {
 	}
 
 	default void transformDefault(DefaultInstance instance, Registration registration) {
+		instance.setRegistry(getRegistry());
 		instance.setNamespace(MetadataContext.LOCAL_NAMESPACE);
 		instance.setService(registration.getServiceId());
 		instance.setProtocol(registration.getScheme());


### PR DESCRIPTION
## PR Type

Bugfix.

## Describe what this PR does for and how you did.

JavaAgent场景下，北极星Registry可能和用户的registry共存。由于polaris-java没有对registry进行区分，因此会出现北极星的优雅上下线处理器和用户的处理器相互覆盖

## Adding the issue link (#xxx) if possible.

closes ##1251

## Note

## Checklist

- [x] Add information of this PR to CHANGELOG.md in root of project.
- [x] Add documentation in javadoc or comment below the PR if necessary.

## Checklist (Optional)

- [x] Will pull request to branch of 2023.0.
- [x] Will pull request to branch of 2022.0.
- [ ] Will pull request to branch of 2020.0.
- [ ] Will pull request to branch of hoxton.
