### PR TITLE
fix: get source service name from upstream application meta in getServerPreSpanAttributes & set custom tag in current server span in tsf.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@
 - [fix: fix get gateway config in tsf ipv6.](https://github.com/Tencent/spring-cloud-tencent/pull/1747)
 - [fix: fix nacos service discovery. ](https://github.com/Tencent/spring-cloud-tencent/pull/1751)
 - [fix:fix NPE when rate-limiting with null value.](https://github.com/Tencent/spring-cloud-tencent/pull/1764)
+- [fix: get source service name from upstream application meta in getServerPreSpanAttributes & set custom tag in current server span in tsf.](https://github.com/Tencent/spring-cloud-tencent/pull/1767)

--- a/spring-cloud-tencent-plugin-starters/spring-cloud-starter-tencent-trace-plugin/src/main/java/com/tencent/cloud/plugin/trace/attribute/PolarisSpanAttributesProvider.java
+++ b/spring-cloud-tencent-plugin-starters/spring-cloud-starter-tencent-trace-plugin/src/main/java/com/tencent/cloud/plugin/trace/attribute/PolarisSpanAttributesProvider.java
@@ -56,13 +56,16 @@ public class PolarisSpanAttributesProvider implements SpanAttributesProvider {
 				attributes.put("custom." + entry.getKey(), entry.getValue());
 			}
 		}
+		Map<String, String> upstreamDisposableApplicationAttributes = metadataContext.getFragmentContext(MetadataContext.FRAGMENT_UPSTREAM_APPLICATION);
+		if (CollectionUtils.isNotEmpty(upstreamDisposableApplicationAttributes)
+				&& upstreamDisposableApplicationAttributes.containsKey(MetadataConstant.DefaultMetadata.DEFAULT_METADATA_SOURCE_SERVICE_NAME)) {
+			attributes.put("net.peer.service",
+					upstreamDisposableApplicationAttributes.get(MetadataConstant.DefaultMetadata.DEFAULT_METADATA_SOURCE_SERVICE_NAME));
+		}
 		Map<String, String> upstreamDisposableCustomAttributes = metadataContext.getFragmentContext(MetadataContext.FRAGMENT_UPSTREAM_DISPOSABLE);
 		if (CollectionUtils.isNotEmpty(upstreamDisposableCustomAttributes)) {
 			for (Map.Entry<String, String> entry : upstreamDisposableCustomAttributes.entrySet()) {
 				attributes.put("custom." + entry.getKey(), entry.getValue());
-				if (MetadataConstant.DefaultMetadata.DEFAULT_METADATA_SOURCE_SERVICE_NAME.equals(entry.getKey())) {
-					attributes.put("net.peer.service", entry.getValue());
-				}
 			}
 		}
 		attributes.put("http.port", CalleeMetadataContainerGroup.getStaticApplicationMetadataContainer()

--- a/spring-cloud-tencent-plugin-starters/spring-cloud-starter-tencent-trace-plugin/src/main/java/com/tencent/cloud/plugin/trace/attribute/tsf/TsfSpanAttributesProvider.java
+++ b/spring-cloud-tencent-plugin-starters/spring-cloud-starter-tencent-trace-plugin/src/main/java/com/tencent/cloud/plugin/trace/attribute/tsf/TsfSpanAttributesProvider.java
@@ -100,12 +100,27 @@ public class TsfSpanAttributesProvider implements SpanAttributesProvider {
 	@Override
 	public Map<String, String> getServerFinallySpanAttributes(EnhancedPluginContext context) {
 		Map<String, String> attributes = new HashMap<>();
-		MetadataObjectValue<Map<String, String>> extraTraceAttributeObject = MetadataContextHolder.get().
+		MetadataContext metadataContext = MetadataContextHolder.get();
+
+		MetadataObjectValue<Map<String, String>> extraTraceAttributeObject = metadataContext.
 				getMetadataContainer(MetadataType.CUSTOM, false).
 				getMetadataValue(ContextConstant.Trace.EXTRA_TRACE_ATTRIBUTES);
 		if (MetadataContextUtils.existMetadataValue(extraTraceAttributeObject)) {
 			Map<String, String> extraTraceAttributes = extraTraceAttributeObject.getObjectValue().get();
 			attributes.putAll(extraTraceAttributes);
+		}
+
+		Map<String, String> transitiveCustomAttributes = metadataContext.getFragmentContext(MetadataContext.FRAGMENT_TRANSITIVE);
+		if (CollectionUtils.isNotEmpty(transitiveCustomAttributes)) {
+			for (Map.Entry<String, String> entry : transitiveCustomAttributes.entrySet()) {
+				attributes.put("custom." + entry.getKey(), entry.getValue());
+			}
+		}
+		Map<String, String> disposableCustomAttributes = metadataContext.getFragmentContext(MetadataContext.FRAGMENT_DISPOSABLE);
+		if (CollectionUtils.isNotEmpty(disposableCustomAttributes)) {
+			for (Map.Entry<String, String> entry : disposableCustomAttributes.entrySet()) {
+				attributes.put("custom." + entry.getKey(), entry.getValue());
+			}
 		}
 		return attributes;
 	}


### PR DESCRIPTION

## PR Type

Bugfix.

## Describe what this PR does for and how you did.
1. fix: get source service name from upstream application meta in getServerPreSpanAttributes
server span 获取远端服务名，之前有问题，是从 caller custom metadata 里拿，sct 有些时候不会自动传，就取不到，改成从 caller application metadata 里拿

2.set custom tag in current server span in tsf.
curl -> consumer -> provider 链路里，如果是 consumer 里手动设置了 Tag，之前只在 consumer -> provider 的 client span 里有打自定义 Tag 信息，consumer 的 server span 里没打印。逻辑上这里其实不需要，但为了和 H/2021 对齐，对齐控制台的用法，所以也要塞

## Adding the issue link (#xxx) if possible.

<!--
closes #
 -->

## Note

## Checklist

- [ ] Add information of this PR to CHANGELOG.md in root of project.
- [ ] Add documentation in javadoc or comment below the PR if necessary.
