### PR TITLE
fix: fix NPE when application context is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@
 - [fix: fix cb rule no update bug.](https://github.com/Tencent/spring-cloud-tencent/pull/1786)
 - [feat: support traffic gray lane router](https://github.com/Tencent/spring-cloud-tencent/pull/1785)
 - [fix: kafka lane support dynamic lane tag.](https://github.com/Tencent/spring-cloud-tencent/pull/1784)
+- [fix: fix NPE when application context is null #1787](https://github.com/Tencent/spring-cloud-tencent/pull/1787)

--- a/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/logging/PolarisLoggingApplicationListener.java
+++ b/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/logging/PolarisLoggingApplicationListener.java
@@ -28,6 +28,7 @@ import org.springframework.boot.context.logging.LoggingApplicationListener;
 import org.springframework.boot.web.context.WebServerInitializedEvent;
 import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
 import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.event.GenericApplicationListener;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -69,7 +70,11 @@ public class PolarisLoggingApplicationListener implements GenericApplicationList
 			environment = ((ApplicationEnvironmentPreparedEvent) applicationEvent).getEnvironment();
 		}
 		else if (ApplicationFailedEvent.class.isAssignableFrom(applicationEvent.getClass())) {
-			environment = ((ApplicationFailedEvent) applicationEvent).getApplicationContext().getEnvironment();
+			ConfigurableApplicationContext configurableApplicationContext = ((ApplicationFailedEvent) applicationEvent)
+					.getApplicationContext();
+			if (configurableApplicationContext != null) {
+				environment = configurableApplicationContext.getEnvironment();
+			}
 		}
 
 		if (environment != null) {


### PR DESCRIPTION
## PR Type
Bugfix.
<!--
Bugfix.
Feature.
Code style update (formatting, local variables).
Refactoring (no functional changes, no api changes).
Documentation content changes.
Other... Please describe:
 -->

## Describe what this PR does for and how you did.

<img width="501" height="216" alt="Clipboard_Screenshot_1768880917" src="https://github.com/user-attachments/assets/2517de26-4aee-4f2f-abac-64f4563f3288" />

同时引入nacos和北极星的依赖，仅使用nacos配置中心且spring.config.import填写错误时，PolarisLoggingApplicationListener报NPE。
（nacos配置的写法是-optional:nacos:filename）
修复前：
<img width="1111" height="362" alt="Clipboard_Screenshot_1768881858" src="https://github.com/user-attachments/assets/99b341d0-308c-4b12-9ff5-dd9b1a4208d5" />

修复后：
<img width="1353" height="332" alt="Clipboard_Screenshot_1768881762" src="https://github.com/user-attachments/assets/8f7f7c0e-6a94-43d3-a0bb-77a60bbb3163" />

## Adding the issue link (#xxx) if possible.

<!--
closes #
 -->

## Note

## Checklist

- [ ] Add information of this PR to CHANGELOG.md in root of project.
- [ ] Add documentation in javadoc or comment below the PR if necessary.
