### PR TITLE
refactor: modify the initialization of ApplicationContextAwareUtils.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 - [feat: Add config address to report client url conversion.](https://github.com/Tencent/spring-cloud-tencent/pull/1795)
 - [feat: Update config server IP to 127.0.0.1 and adjust tests.](https://github.com/Tencent/spring-cloud-tencent/pull/1796)
 - [feat: Support Polaris config env value and add related tests](https://github.com/Tencent/spring-cloud-tencent/pull/1797)
-- [refactor: modify the initialization of ApplicationContextAwareUtils.](https://github.com/Tencent/spring-cloud-tencent/pull/1778)
+- [refactor: modify the initialization of ApplicationContextAwareUtils.](https://github.com/Tencent/spring-cloud-tencent/pull/1798)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - [feat: Add config address to report client url conversion.](https://github.com/Tencent/spring-cloud-tencent/pull/1795)
 - [feat: Update config server IP to 127.0.0.1 and adjust tests.](https://github.com/Tencent/spring-cloud-tencent/pull/1796)
 - [feat: Support Polaris config env value and add related tests](https://github.com/Tencent/spring-cloud-tencent/pull/1797)
+- [refactor: modify the initialization of ApplicationContextAwareUtils.](https://github.com/Tencent/spring-cloud-tencent/pull/1778)

--- a/spring-cloud-starter-tencent-polaris-circuitbreaker/src/test/java/com/tencent/cloud/polaris/circuitbreaker/endpoint/PolarisCircuitBreakerEndpointTest.java
+++ b/spring-cloud-starter-tencent-polaris-circuitbreaker/src/test/java/com/tencent/cloud/polaris/circuitbreaker/endpoint/PolarisCircuitBreakerEndpointTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
 public class PolarisCircuitBreakerEndpointTest {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withBean(ApplicationContextAwareUtils.class)
+			.withInitializer(new ApplicationContextAwareUtils())
 			.withPropertyValues("spring.cloud.polaris.namespace=" + NAMESPACE_TEST)
 			.withPropertyValues("spring.cloud.polaris.service=" + SERVICE_PROVIDER);
 

--- a/spring-cloud-starter-tencent-polaris-discovery/src/test/java/com/tencent/cloud/polaris/discovery/PolarisServiceDiscoveryTest.java
+++ b/spring-cloud-starter-tencent-polaris-discovery/src/test/java/com/tencent/cloud/polaris/discovery/PolarisServiceDiscoveryTest.java
@@ -19,14 +19,12 @@ package com.tencent.cloud.polaris.discovery;
 
 import java.util.List;
 
-import com.tencent.cloud.common.util.ApplicationContextAwareUtils;
 import com.tencent.polaris.api.exception.PolarisException;
 import com.tencent.polaris.api.pojo.DefaultInstance;
 import com.tencent.polaris.api.pojo.DefaultServiceInstances;
 import com.tencent.polaris.api.pojo.ServiceInfo;
 import com.tencent.polaris.api.rpc.InstancesResponse;
 import com.tencent.polaris.api.rpc.ServicesResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -36,7 +34,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.support.StaticApplicationContext;
 
 import static com.tencent.polaris.test.common.Consts.SERVICE_PROVIDER;
 import static java.util.Collections.singletonList;
@@ -57,11 +54,6 @@ public class PolarisServiceDiscoveryTest {
 	private PolarisDiscoveryHandler polarisDiscoveryHandler;
 	@InjectMocks
 	private PolarisServiceDiscovery polarisServiceDiscovery;
-
-	@BeforeEach
-	void setUp() {
-		new ApplicationContextAwareUtils().setApplicationContext(new StaticApplicationContext());
-	}
 
 	@Test
 	public void testGetInstances() {

--- a/spring-cloud-starter-tencent-polaris-ratelimit/src/test/java/com/tencent/cloud/polaris/ratelimit/endpoint/PolarisRateLimitRuleEndpointTests.java
+++ b/spring-cloud-starter-tencent-polaris-ratelimit/src/test/java/com/tencent/cloud/polaris/ratelimit/endpoint/PolarisRateLimitRuleEndpointTests.java
@@ -19,6 +19,7 @@ package com.tencent.cloud.polaris.ratelimit.endpoint;
 
 import java.util.Map;
 
+import com.tencent.cloud.common.util.ApplicationContextAwareUtils;
 import com.tencent.cloud.polaris.context.ServiceRuleManager;
 import com.tencent.cloud.polaris.ratelimit.config.PolarisRateLimitProperties;
 import com.tencent.polaris.specification.api.v1.model.ModelProto;
@@ -57,6 +58,7 @@ public class PolarisRateLimitRuleEndpointTests {
 					PolarisRateLimitRuleEndpointAutoConfiguration.class,
 					PolarisRateLimitAutoConfiguration.class,
 					PolarisRateLimitAutoConfiguration.class))
+			.withInitializer(new ApplicationContextAwareUtils())
 			.withPropertyValues("spring.application.name=" + SERVICE_PROVIDER)
 			.withPropertyValues("server.port=" + PORT)
 			.withPropertyValues("spring.cloud.polaris.address=grpc://127.0.0.1:10081")

--- a/spring-cloud-starter-tencent-polaris-router/src/test/java/com/tencent/cloud/polaris/router/config/FeignAutoConfigurationTest.java
+++ b/spring-cloud-starter-tencent-polaris-router/src/test/java/com/tencent/cloud/polaris/router/config/FeignAutoConfigurationTest.java
@@ -40,9 +40,10 @@ public class FeignAutoConfigurationTest {
 					RouterAutoConfiguration.class,
 					RouterConfigModifierAutoConfiguration.class,
 					PolarisContextAutoConfiguration.class,
-					FeignAutoConfiguration.class,
-					ApplicationContextAwareUtils.class
-			)).withPropertyValues("spring.application.name=test");
+					FeignAutoConfiguration.class
+			))
+			.withInitializer(new ApplicationContextAwareUtils())
+			.withPropertyValues("spring.application.name=test");
 
 	@Test
 	public void routerLabelInterceptor() {

--- a/spring-cloud-starter-tencent-polaris-router/src/test/java/com/tencent/cloud/polaris/router/config/RouterAutoConfigurationTests.java
+++ b/spring-cloud-starter-tencent-polaris-router/src/test/java/com/tencent/cloud/polaris/router/config/RouterAutoConfigurationTests.java
@@ -43,9 +43,10 @@ public class RouterAutoConfigurationTests {
 					RouterAutoConfiguration.class,
 					RouterConfigModifierAutoConfiguration.class,
 					PolarisContextAutoConfiguration.class,
-					RouterAutoConfiguration.RouterLabelRestTemplateConfig.class,
-					ApplicationContextAwareUtils.class
-			)).withPropertyValues("spring.application.name=test");
+					RouterAutoConfiguration.RouterLabelRestTemplateConfig.class
+			))
+			.withInitializer(new ApplicationContextAwareUtils())
+			.withPropertyValues("spring.application.name=test");
 
 	@Test
 	public void testRouterLabelRestTemplateConfig() {

--- a/spring-cloud-tencent-commons/src/main/java/com/tencent/cloud/common/metadata/config/MetadataAutoConfiguration.java
+++ b/spring-cloud-tencent-commons/src/main/java/com/tencent/cloud/common/metadata/config/MetadataAutoConfiguration.java
@@ -22,7 +22,6 @@ import java.util.List;
 import com.tencent.cloud.common.metadata.StaticMetadataManager;
 import com.tencent.cloud.common.spi.InstanceMetadataProvider;
 import com.tencent.cloud.common.spi.impl.DefaultInstanceMetadataProvider;
-import com.tencent.cloud.common.util.ApplicationContextAwareUtils;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -46,8 +45,8 @@ public class MetadataAutoConfiguration {
 	}
 
 	@Bean
-	public InstanceMetadataProvider defaultInstanceMetadataProvider(ApplicationContextAwareUtils applicationContextAwareUtils) {
-		return new DefaultInstanceMetadataProvider(applicationContextAwareUtils);
+	public InstanceMetadataProvider defaultInstanceMetadataProvider() {
+		return new DefaultInstanceMetadataProvider();
 	}
 
 	@Bean

--- a/spring-cloud-tencent-commons/src/main/java/com/tencent/cloud/common/spi/impl/DefaultInstanceMetadataProvider.java
+++ b/spring-cloud-tencent-commons/src/main/java/com/tencent/cloud/common/spi/impl/DefaultInstanceMetadataProvider.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.tencent.cloud.common.spi.InstanceMetadataProvider;
-import com.tencent.cloud.common.util.ApplicationContextAwareUtils;
 import com.tencent.cloud.common.util.inet.PolarisInetUtils;
 import com.tencent.polaris.api.utils.StringUtils;
 import com.tencent.polaris.metadata.core.constant.MetadataConstants;
@@ -41,13 +40,6 @@ import static com.tencent.cloud.common.metadata.MetadataContext.LOCAL_SERVICE;
  * @author sean yu
  */
 public class DefaultInstanceMetadataProvider implements InstanceMetadataProvider {
-
-	private final ApplicationContextAwareUtils applicationContextAwareUtils;
-
-	// ensure ApplicationContextAwareUtils init before
-	public DefaultInstanceMetadataProvider(ApplicationContextAwareUtils applicationContextAwareUtils) {
-		this.applicationContextAwareUtils = applicationContextAwareUtils;
-	}
 
 	@Override
 	public Map<String, String> getMetadata() {

--- a/spring-cloud-tencent-commons/src/main/java/com/tencent/cloud/common/util/ApplicationContextAwareUtils.java
+++ b/spring-cloud-tencent-commons/src/main/java/com/tencent/cloud/common/util/ApplicationContextAwareUtils.java
@@ -18,20 +18,20 @@
 package com.tencent.cloud.common.util;
 
 import com.tencent.polaris.api.utils.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.lang.NonNull;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
 
 /**
  * Spring Context Util.
  *
  * @author Hongwei Zhu
  */
-public class ApplicationContextAwareUtils implements ApplicationContextAware {
+public class ApplicationContextAwareUtils implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationContextAwareUtils.class);
 
@@ -43,11 +43,6 @@ public class ApplicationContextAwareUtils implements ApplicationContextAware {
 	 */
 	public static ApplicationContext getApplicationContext() {
 		return applicationContext;
-	}
-
-	@Override
-	public void setApplicationContext(@NonNull ApplicationContext applicationContext) throws BeansException {
-		ApplicationContextAwareUtils.applicationContext = applicationContext;
 	}
 
 	/**
@@ -106,5 +101,10 @@ public class ApplicationContextAwareUtils implements ApplicationContextAware {
 			}
 			return null;
 		}
+	}
+
+	@Override
+	public void initialize(@NotNull ConfigurableApplicationContext applicationContext) {
+		ApplicationContextAwareUtils.applicationContext = applicationContext;
 	}
 }

--- a/spring-cloud-tencent-commons/src/main/java/com/tencent/cloud/common/util/ApplicationContextAwareUtils.java
+++ b/spring-cloud-tencent-commons/src/main/java/com/tencent/cloud/common/util/ApplicationContextAwareUtils.java
@@ -18,7 +18,6 @@
 package com.tencent.cloud.common.util;
 
 import com.tencent.polaris.api.utils.StringUtils;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,7 +103,7 @@ public class ApplicationContextAwareUtils implements ApplicationContextInitializ
 	}
 
 	@Override
-	public void initialize(@NotNull ConfigurableApplicationContext applicationContext) {
+	public void initialize(ConfigurableApplicationContext applicationContext) {
 		ApplicationContextAwareUtils.applicationContext = applicationContext;
 	}
 }

--- a/spring-cloud-tencent-commons/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-tencent-commons/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,4 @@
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
   com.tencent.cloud.common.util.inet.PolarisInetUtilsBootstrapConfiguration
+org.springframework.context.ApplicationContextInitializer=\
+  com.tencent.cloud.common.util.ApplicationContextAwareUtils

--- a/spring-cloud-tencent-commons/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-cloud-tencent-commons/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,4 +1,3 @@
-com.tencent.cloud.common.util.ApplicationContextAwareUtils
 com.tencent.cloud.common.metadata.config.MetadataAutoConfiguration
 com.tencent.cloud.common.metadata.endpoint.PolarisMetadataEndpointAutoConfiguration
 com.tencent.cloud.common.util.inet.PolarisInetUtilsAutoConfiguration

--- a/spring-cloud-tencent-commons/src/test/java/com/tencent/cloud/common/metadata/StaticMetadataManagerTest.java
+++ b/spring-cloud-tencent-commons/src/test/java/com/tencent/cloud/common/metadata/StaticMetadataManagerTest.java
@@ -133,7 +133,7 @@ public class StaticMetadataManagerTest {
 		when(metadataLocalProperties.getTransitive()).thenReturn(Collections.singletonList("k1"));
 
 		StaticMetadataManager metadataManager = new StaticMetadataManager(metadataLocalProperties,
-				Arrays.asList(new MockedMetadataProvider(), new DefaultInstanceMetadataProvider(null)));
+				Arrays.asList(new MockedMetadataProvider(), new DefaultInstanceMetadataProvider()));
 
 		Map<String, String> metadata = metadataManager.getAllCustomMetadata();
 		assertThat(metadata.size()).isGreaterThanOrEqualTo(5);
@@ -178,7 +178,7 @@ public class StaticMetadataManagerTest {
 		when(metadataLocalProperties.getHeaders()).thenReturn(Arrays.asList("b", "d"));
 
 		StaticMetadataManager metadataManager = new StaticMetadataManager(metadataLocalProperties,
-				Arrays.asList(new MockedMetadataProvider(), new DefaultInstanceMetadataProvider(null)));
+				Arrays.asList(new MockedMetadataProvider(), new DefaultInstanceMetadataProvider()));
 
 		Map<String, String> metadata = metadataManager.getMergedStaticMetadata();
 		assertThat(metadata.size()).isGreaterThanOrEqualTo(8);

--- a/spring-cloud-tencent-commons/src/test/java/com/tencent/cloud/common/metadata/config/MetadataAutoConfigurationTest.java
+++ b/spring-cloud-tencent-commons/src/test/java/com/tencent/cloud/common/metadata/config/MetadataAutoConfigurationTest.java
@@ -52,7 +52,8 @@ public class MetadataAutoConfigurationTest {
 	@Test
 	public void test1() {
 		this.applicationContextRunner
-				.withConfiguration(AutoConfigurations.of(MetadataAutoConfiguration.class, ApplicationContextAwareUtils.class))
+				.withConfiguration(AutoConfigurations.of(MetadataAutoConfiguration.class))
+				.withInitializer(new ApplicationContextAwareUtils())
 				.run(context -> {
 					Assertions.assertThat(context).hasSingleBean(MetadataLocalProperties.class);
 				});
@@ -64,7 +65,8 @@ public class MetadataAutoConfigurationTest {
 	@Test
 	public void test2() {
 		this.webApplicationContextRunner
-				.withConfiguration(AutoConfigurations.of(MetadataAutoConfiguration.class, ApplicationContextAwareUtils.class))
+				.withConfiguration(AutoConfigurations.of(MetadataAutoConfiguration.class))
+				.withInitializer(new ApplicationContextAwareUtils())
 				.run(context -> {
 					Assertions.assertThat(context).hasSingleBean(MetadataLocalProperties.class);
 				});
@@ -76,7 +78,8 @@ public class MetadataAutoConfigurationTest {
 	@Test
 	public void test3() {
 		this.reactiveWebApplicationContextRunner
-				.withConfiguration(AutoConfigurations.of(MetadataAutoConfiguration.class, ApplicationContextAwareUtils.class))
+				.withConfiguration(AutoConfigurations.of(MetadataAutoConfiguration.class))
+				.withInitializer(new ApplicationContextAwareUtils())
 				.run(context -> {
 					Assertions.assertThat(context).hasSingleBean(MetadataLocalProperties.class);
 				});

--- a/spring-cloud-tencent-commons/src/test/java/com/tencent/cloud/common/util/ApplicationContextAwareUtilsTest.java
+++ b/spring-cloud-tencent-commons/src/test/java/com/tencent/cloud/common/util/ApplicationContextAwareUtilsTest.java
@@ -21,8 +21,8 @@ import com.tencent.cloud.common.async.PolarisAsyncConfiguration;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -35,13 +35,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class ApplicationContextAwareUtilsTest {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(ApplicationContextAwareUtils.class))
+			.withInitializer(new ApplicationContextAwareUtils())
+			.withUserConfiguration(TestConfig.class)
 			.withPropertyValues("key1=value1");
 
 	@Test
 	public void testApplicationContextAwareUtils() {
 		this.contextRunner.run(context -> {
-			assertThat(context).hasSingleBean(ApplicationContextAwareUtils.class);
 			assertThat(ApplicationContextAwareUtils.getApplicationContext()).isNotNull();
 
 			// test getProperties
@@ -53,14 +53,19 @@ public class ApplicationContextAwareUtilsTest {
 			assertThat(ApplicationContextAwareUtils.getProperties("key2", "defaultValue")).isEqualTo("defaultValue");
 
 			// test getBean
-			assertThat(ApplicationContextAwareUtils.getBean(ApplicationContextAwareUtils.class)).isNotNull();
+			assertThat(ApplicationContextAwareUtils.getBean(TestConfig.class)).isNotNull();
 			assertThatThrownBy(() -> {
 				ApplicationContextAwareUtils.getBean(PolarisAsyncConfiguration.class);
 			}).isInstanceOf(NoSuchBeanDefinitionException.class);
 
 			// test getBeanIfExists
-			assertThat(ApplicationContextAwareUtils.getBeanIfExists(ApplicationContextAwareUtils.class)).isNotNull();
-			assertThat(ApplicationContextAwareUtils.getBeanIfExists(PolarisAsyncConfiguration.class)).isNull();
+			assertThat(ApplicationContextAwareUtils.getBeanIfExists(TestConfig.class)).isNotNull();
+			assertThat(ApplicationContextAwareUtils.getBeanIfExists(PolarisAsyncConfiguration.class, true)).isNull();
 		});
+	}
+
+	@Configuration
+	static class TestConfig {
+
 	}
 }

--- a/spring-cloud-tencent-commons/src/test/java/org/springframework/tsf/core/util/TsfSpringContextAwareTest.java
+++ b/spring-cloud-tencent-commons/src/test/java/org/springframework/tsf/core/util/TsfSpringContextAwareTest.java
@@ -22,8 +22,8 @@ import com.tencent.cloud.common.util.ApplicationContextAwareUtils;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -37,7 +37,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TsfSpringContextAwareTest {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(ApplicationContextAwareUtils.class))
+			.withInitializer(new ApplicationContextAwareUtils())
+			.withUserConfiguration(TestConfig.class)
 			.withPropertyValues("key1=value1");
 
 	@Test
@@ -56,10 +57,15 @@ public class TsfSpringContextAwareTest {
 			assertThat(TsfSpringContextAware.getProperties("key2", "defaultValue")).isEqualTo("defaultValue");
 
 			// test getBean
-			assertThat(TsfSpringContextAware.getBean(ApplicationContextAwareUtils.class)).isNotNull();
+			assertThat(TsfSpringContextAware.getBean(TestConfig.class)).isNotNull();
 			assertThatThrownBy(() -> {
 				TsfSpringContextAware.getBean(PolarisAsyncConfiguration.class);
 			}).isInstanceOf(NoSuchBeanDefinitionException.class);
 		});
+	}
+
+	@Configuration
+	static class TestConfig {
+
 	}
 }

--- a/spring-cloud-tencent-examples/quickstart-example/quickstart-callee-service-b/src/main/java/com/tencent/cloud/quickstart/callee/service/CalleeServiceChangeCallback.java
+++ b/spring-cloud-tencent-examples/quickstart-example/quickstart-callee-service-b/src/main/java/com/tencent/cloud/quickstart/callee/service/CalleeServiceChangeCallback.java
@@ -1,0 +1,60 @@
+/*
+ * Tencent is pleased to support the open source community by making spring-cloud-tencent available.
+ *
+ * Copyright (C) 2021 Tencent. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.cloud.quickstart.callee.service;
+
+import java.util.List;
+
+import com.tencent.cloud.polaris.discovery.refresh.ServiceInstanceChangeCallback;
+import com.tencent.cloud.polaris.discovery.refresh.ServiceInstanceChangeListener;
+import com.tencent.polaris.api.pojo.Instance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Call back for QuickstartCalleeService.
+ *
+ * @author Haotian Zhang
+ */
+@Component
+@ServiceInstanceChangeListener(serviceName = "QuickstartCalleeService")
+public class CalleeServiceChangeCallback implements ServiceInstanceChangeCallback {
+
+	private static final Logger LOG = LoggerFactory.getLogger(CalleeServiceChangeCallback.class);
+
+	@Override
+	public void callback(List<Instance> currentServiceInstances, List<Instance> addServiceInstances, List<Instance> deleteServiceInstances) {
+		String current = generateNodeList(currentServiceInstances);
+		String add = generateNodeList(addServiceInstances);
+		String delete = generateNodeList(deleteServiceInstances);
+		LOG.info("current: {}, add: {}, delete: {}", current, add, delete);
+	}
+
+	private String generateNodeList(List<Instance> deleteServiceInstances) {
+		StringBuilder nodeListStr = new StringBuilder("[");
+		for (Instance instance : deleteServiceInstances) {
+			if (nodeListStr.length() > 1) {
+				nodeListStr.append(", ");
+			}
+			nodeListStr.append(instance.getHost()).append(":").append(instance.getPort());
+		}
+		nodeListStr.append("]");
+		return nodeListStr.toString();
+	}
+}

--- a/spring-cloud-tencent-plugin-starters/spring-cloud-starter-tencent-tsf-tls-plugin/src/main/java/com/tencent/cloud/plugin/tsf/tls/TlsReadyApplicationListener.java
+++ b/spring-cloud-tencent-plugin-starters/spring-cloud-starter-tencent-tsf-tls-plugin/src/main/java/com/tencent/cloud/plugin/tsf/tls/TlsReadyApplicationListener.java
@@ -42,8 +42,8 @@ public class TlsReadyApplicationListener implements ApplicationListener<Applicat
 
 	@Override
 	public void onApplicationEvent(@NotNull ApplicationStartedEvent event) {
-		SslBundles sslBundles = ApplicationContextAwareUtils.getBeanIfExists(SslBundles.class);
-		ContextRefresher contextRefresher = ApplicationContextAwareUtils.getBeanIfExists(ContextRefresher.class);
+		SslBundles sslBundles = ApplicationContextAwareUtils.getBeanIfExists(SslBundles.class, true);
+		ContextRefresher contextRefresher = ApplicationContextAwareUtils.getBeanIfExists(ContextRefresher.class, true);
 		try {
 			if (sslBundles != null && contextRefresher != null && isSet.compareAndSet(false, true)
 					&& sslBundles.getBundleNames().contains("tsf")) {


### PR DESCRIPTION
## PR Type

Refactoring (no functional changes, no api changes).

## Describe what this PR does for and how you did.

Refactor `ApplicationContextAwareUtils` from `ApplicationContextAware` to `ApplicationContextInitializer` to ensure it is initialized earlier in the Spring lifecycle (before `refresh()`), which resolves potential timing issues when other beans try to use it during initialization.

Key changes:
- `ApplicationContextAwareUtils` now implements `ApplicationContextInitializer<ConfigurableApplicationContext>` instead of `ApplicationContextAware`
- Registered via `spring.factories` under `ApplicationContextInitializer` key instead of `EnableAutoConfiguration`
- Removed from `AutoConfiguration.imports`
- `DefaultInstanceMetadataProvider` no longer needs `ApplicationContextAwareUtils` injected via constructor
- All tests updated to use `.withInitializer(new ApplicationContextAwareUtils())` instead of `.withBean()`/`withConfiguration()`
- `TlsReadyApplicationListener` updated to use explicit `warnIfFailed` parameter

## Adding the issue link (#xxx) if possible.

closes #1779

## Checklist

- [x] Add information of this PR to CHANGELOG.md in root of project.