### PR TITLE
feat: support overrideHost configuration for ratelimit, event reporter and stat modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - [feat: refactor Feign eager load, add LoadBalancer warm-up, and fix gateway trailing slash compatibility](https://github.com/Tencent/spring-cloud-tencent/pull/1800)
 - [test: add unit tests for ConfigurationModifier and fix TsfConsul report logic](https://github.com/Tencent/spring-cloud-tencent/pull/1802)
 - [fix: prepend context-path to contract reporter API paths](https://github.com/Tencent/spring-cloud-tencent/pull/1803)
+- [feat: support overrideHost configuration for ratelimit, event reporter and stat modules](https://github.com/Tencent/spring-cloud-tencent/pull/1804)

--- a/spring-cloud-starter-tencent-polaris-ratelimit/src/main/java/com/tencent/cloud/polaris/ratelimit/config/PolarisRateLimitProperties.java
+++ b/spring-cloud-starter-tencent-polaris-ratelimit/src/main/java/com/tencent/cloud/polaris/ratelimit/config/PolarisRateLimitProperties.java
@@ -50,6 +50,8 @@ public class PolarisRateLimitProperties {
 
 	private String limiterAddresses;
 
+	private String limiterOverrideHost;
+
 	private long remoteTaskInterval = 30L;
 
 	String getLimiterAddresses() {
@@ -58,6 +60,14 @@ public class PolarisRateLimitProperties {
 
 	void setLimiterAddresses(String limiterAddresses) {
 		this.limiterAddresses = limiterAddresses;
+	}
+
+	String getLimiterOverrideHost() {
+		return limiterOverrideHost;
+	}
+
+	void setLimiterOverrideHost(String limiterOverrideHost) {
+		this.limiterOverrideHost = limiterOverrideHost;
 	}
 
 	public String getRejectRequestTips() {

--- a/spring-cloud-starter-tencent-polaris-ratelimit/src/main/java/com/tencent/cloud/polaris/ratelimit/config/RateLimitConfigModifier.java
+++ b/spring-cloud-starter-tencent-polaris-ratelimit/src/main/java/com/tencent/cloud/polaris/ratelimit/config/RateLimitConfigModifier.java
@@ -43,6 +43,7 @@ public class RateLimitConfigModifier implements PolarisConfigModifier {
 		configuration.getProvider().getRateLimit()
 				.setLimiterAddresses(AddressUtils.parseHostPortList(polarisRateLimitProperties.getLimiterAddresses()));
 		configuration.getProvider().getRateLimit().setRemoteTaskIntervalMilli(polarisRateLimitProperties.getRemoteTaskInterval());
+		configuration.getProvider().getRateLimit().setLimiterOverrideHost(polarisRateLimitProperties.getLimiterOverrideHost());
 	}
 
 	@Override

--- a/spring-cloud-starter-tencent-polaris-ratelimit/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-starter-tencent-polaris-ratelimit/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -40,6 +40,11 @@
       "type": "java.lang.Long",
       "defaultValue": "30",
       "description": "Remote limiter service task base interval. Unit: ms."
+    },
+    {
+      "name": "spring.cloud.polaris.ratelimit.limiterOverrideHost",
+      "type": "java.lang.String",
+      "description": "Override host for remote limiter service. When set, all limiter instance IPs will be replaced with this value while preserving original ports."
     }
   ]
 }

--- a/spring-cloud-starter-tencent-polaris-ratelimit/src/test/java/com/tencent/cloud/polaris/ratelimit/config/PolarisRateLimitConfigModifierTest.java
+++ b/spring-cloud-starter-tencent-polaris-ratelimit/src/test/java/com/tencent/cloud/polaris/ratelimit/config/PolarisRateLimitConfigModifierTest.java
@@ -34,7 +34,8 @@ public class PolarisRateLimitConfigModifierTest {
 			.withConfiguration(AutoConfigurations.of(TestApplication.class))
 			.withPropertyValues("spring.cloud.polaris.ratelimit.maxQueuingTime=500")
 			.withPropertyValues("spring.cloud.polaris.ratelimit.limiterAddresses=127.0.0.1:8080,127.0.0.1:8081")
-			.withPropertyValues("spring.cloud.polaris.ratelimit.remoteTaskInterval=50");
+			.withPropertyValues("spring.cloud.polaris.ratelimit.remoteTaskInterval=50")
+			.withPropertyValues("spring.cloud.polaris.ratelimit.limiterOverrideHost=127.0.0.1");
 
 	@BeforeEach
 	void setUp() {
@@ -52,6 +53,7 @@ public class PolarisRateLimitConfigModifierTest {
 			assertThat(config.getLimiterAddresses().get(1)).isEqualTo("127.0.0.1:8081");
 			assertThat(config.getMaxQueuingTime()).isEqualTo(500);
 			assertThat(config.getRemoteTaskIntervalMilli()).isEqualTo(50);
+			assertThat(config.getLimiterOverrideHost()).isEqualTo("127.0.0.1");
 		});
 	}
 

--- a/spring-cloud-starter-tencent-polaris-ratelimit/src/test/java/com/tencent/cloud/polaris/ratelimit/config/PolarisRateLimitPropertiesTest.java
+++ b/spring-cloud-starter-tencent-polaris-ratelimit/src/test/java/com/tencent/cloud/polaris/ratelimit/config/PolarisRateLimitPropertiesTest.java
@@ -54,6 +54,7 @@ public class PolarisRateLimitPropertiesTest {
 		assertThat(polarisRateLimitProperties.getRemoteTaskInterval()).isEqualTo(50L);
 		List<String> limiterAddresses = AddressUtils.parseHostPortList(polarisRateLimitProperties.getLimiterAddresses());
 		assertThat(limiterAddresses.get(0)).isEqualTo("127.0.0.1:8080");
+		assertThat(polarisRateLimitProperties.getLimiterOverrideHost()).isEqualTo("127.0.0.1");
 
 	}
 

--- a/spring-cloud-starter-tencent-polaris-ratelimit/src/test/resources/application-test.properties
+++ b/spring-cloud-starter-tencent-polaris-ratelimit/src/test/resources/application-test.properties
@@ -4,3 +4,4 @@ spring.cloud.polaris.ratelimit.rejectHttpCode=419
 spring.cloud.polaris.ratelimit.maxQueuingTime=500
 spring.cloud.polaris.ratelimit.remoteTaskInterval=50
 spring.cloud.polaris.ratelimit.limiterAddresses=127.0.0.1:8080,127.0.0.1:8081
+spring.cloud.polaris.ratelimit.limiterOverrideHost=127.0.0.1

--- a/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/event/PushGatewayEventReporterConfigModifier.java
+++ b/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/event/PushGatewayEventReporterConfigModifier.java
@@ -55,6 +55,7 @@ public class PushGatewayEventReporterConfigModifier implements PolarisConfigModi
 		pushGatewayEventReporterConfig.setMaxBatchSize(properties.getMaxBatchSize());
 		pushGatewayEventReporterConfig.setNamespace(properties.getNamespace());
 		pushGatewayEventReporterConfig.setService(properties.getService());
+		pushGatewayEventReporterConfig.setOverrideHost(properties.getOverrideHost());
 
 		configuration.getGlobal().getEventReporter()
 				.setPluginConfig(DefaultPlugins.PUSH_GATEWAY_EVENT_REPORTER_TYPE, pushGatewayEventReporterConfig);

--- a/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/event/PushGatewayEventReporterProperties.java
+++ b/spring-cloud-tencent-polaris-context/src/main/java/com/tencent/cloud/polaris/context/event/PushGatewayEventReporterProperties.java
@@ -58,6 +58,11 @@ public class PushGatewayEventReporterProperties {
 	 */
 	private String service = "polaris.pushgateway";
 
+	/**
+	 * Override host for push gateway event reporter.
+	 */
+	private String overrideHost;
+
 	public boolean isEnabled() {
 		return enabled;
 	}
@@ -106,6 +111,14 @@ public class PushGatewayEventReporterProperties {
 		this.service = service;
 	}
 
+	public String getOverrideHost() {
+		return overrideHost;
+	}
+
+	public void setOverrideHost(String overrideHost) {
+		this.overrideHost = overrideHost;
+	}
+
 	@Override
 	public String toString() {
 		return "PushGatewayEventReporterProperties{" +
@@ -115,6 +128,7 @@ public class PushGatewayEventReporterProperties {
 				", maxBatchSize=" + maxBatchSize +
 				", namespace='" + namespace + '\'' +
 				", service='" + service + '\'' +
+				", overrideHost='" + overrideHost + '\'' +
 				'}';
 	}
 }

--- a/spring-cloud-tencent-polaris-context/src/test/java/com/tencent/cloud/polaris/context/event/PushGatewayEventReporterConfigModifierTest.java
+++ b/spring-cloud-tencent-polaris-context/src/test/java/com/tencent/cloud/polaris/context/event/PushGatewayEventReporterConfigModifierTest.java
@@ -43,7 +43,8 @@ public class PushGatewayEventReporterConfigModifierTest {
 			.withPropertyValues("spring.cloud.polaris.event.pushgateway.eventQueueSize=123")
 			.withPropertyValues("spring.cloud.polaris.event.pushgateway.maxBatchSize=456")
 			.withPropertyValues("spring.cloud.polaris.event.pushgateway.namespace=test-namespace")
-			.withPropertyValues("spring.cloud.polaris.event.pushgateway.service=test-service");
+			.withPropertyValues("spring.cloud.polaris.event.pushgateway.service=test-service")
+			.withPropertyValues("spring.cloud.polaris.event.pushgateway.overrideHost=127.0.0.1");
 
 	@BeforeEach
 	void setUp() {
@@ -64,6 +65,7 @@ public class PushGatewayEventReporterConfigModifierTest {
 			assertThat(config.getMaxBatchSize()).isEqualTo(456);
 			assertThat(config.getNamespace()).isEqualTo("test-namespace");
 			assertThat(config.getService()).isEqualTo("test-service");
+			assertThat(config.getOverrideHost()).isEqualTo("127.0.0.1");
 		});
 	}
 }

--- a/spring-cloud-tencent-polaris-context/src/test/java/com/tencent/cloud/polaris/context/event/PushGatewayEventReporterPropertiesTest.java
+++ b/spring-cloud-tencent-polaris-context/src/test/java/com/tencent/cloud/polaris/context/event/PushGatewayEventReporterPropertiesTest.java
@@ -44,7 +44,8 @@ public class PushGatewayEventReporterPropertiesTest {
 			.withPropertyValues("spring.cloud.polaris.event.pushgateway.eventQueueSize=123")
 			.withPropertyValues("spring.cloud.polaris.event.pushgateway.maxBatchSize=456")
 			.withPropertyValues("spring.cloud.polaris.event.pushgateway.namespace=test-namespace")
-			.withPropertyValues("spring.cloud.polaris.event.pushgateway.service=test-service");
+			.withPropertyValues("spring.cloud.polaris.event.pushgateway.service=test-service")
+			.withPropertyValues("spring.cloud.polaris.event.pushgateway.overrideHost=127.0.0.1");
 
 	@BeforeEach
 	void setUp() {
@@ -63,6 +64,7 @@ public class PushGatewayEventReporterPropertiesTest {
 			assertThat(properties.getMaxBatchSize()).isEqualTo(456);
 			assertThat(properties.getNamespace()).isEqualTo("test-namespace");
 			assertThat(properties.getService()).isEqualTo("test-service");
+			assertThat(properties.getOverrideHost()).isEqualTo("127.0.0.1");
 		});
 	}
 }

--- a/spring-cloud-tencent-rpc-enhancement/src/main/java/com/tencent/cloud/rpc/enhancement/stat/config/PolarisStatProperties.java
+++ b/spring-cloud-tencent-rpc-enhancement/src/main/java/com/tencent/cloud/rpc/enhancement/stat/config/PolarisStatProperties.java
@@ -83,6 +83,12 @@ public class PolarisStatProperties {
 	 */
 	private List<String> pathRegexList = new ArrayList<>();
 
+	/**
+	 * Override host for prometheus push gateway.
+	 */
+	@Value("${spring.cloud.polaris.stat.pushgateway.override-host:}")
+	private String pushGatewayOverrideHost;
+
 	public boolean isEnabled() {
 		return enabled;
 	}
@@ -155,6 +161,14 @@ public class PolarisStatProperties {
 		this.pathRegexList = pathRegexList;
 	}
 
+	public String getPushGatewayOverrideHost() {
+		return pushGatewayOverrideHost;
+	}
+
+	public void setPushGatewayOverrideHost(String pushGatewayOverrideHost) {
+		this.pushGatewayOverrideHost = pushGatewayOverrideHost;
+	}
+
 	@Override
 	public String toString() {
 		return "PolarisStatProperties{" +
@@ -167,6 +181,7 @@ public class PolarisStatProperties {
 				", pushGatewayPushInterval=" + pushGatewayPushInterval +
 				", openGzip=" + openGzip +
 				", pathRegexList=" + pathRegexList +
+				", pushGatewayOverrideHost='" + pushGatewayOverrideHost + '\'' +
 				'}';
 	}
 }

--- a/spring-cloud-tencent-rpc-enhancement/src/main/java/com/tencent/cloud/rpc/enhancement/stat/config/StatConfigModifier.java
+++ b/spring-cloud-tencent-rpc-enhancement/src/main/java/com/tencent/cloud/rpc/enhancement/stat/config/StatConfigModifier.java
@@ -57,6 +57,7 @@ public class StatConfigModifier implements PolarisConfigModifier {
 				prometheusHandlerConfig.setService(polarisStatProperties.getStatService());
 				prometheusHandlerConfig.setPushInterval(polarisStatProperties.getPushGatewayPushInterval());
 				prometheusHandlerConfig.setOpenGzip(polarisStatProperties.getOpenGzip());
+				prometheusHandlerConfig.setOverrideHost(polarisStatProperties.getPushGatewayOverrideHost());
 			}
 			else {
 				// pull metrics

--- a/spring-cloud-tencent-rpc-enhancement/src/test/java/com/tencent/cloud/rpc/enhancement/stat/config/PolarisStatPropertiesTest.java
+++ b/spring-cloud-tencent-rpc-enhancement/src/test/java/com/tencent/cloud/rpc/enhancement/stat/config/PolarisStatPropertiesTest.java
@@ -44,6 +44,7 @@ public class PolarisStatPropertiesTest {
 			.withPropertyValues("spring.cloud.polaris.stat.pushgateway.namespace=test-namespace")
 			.withPropertyValues("spring.cloud.polaris.stat.pushgateway.service=test-service")
 			.withPropertyValues("spring.cloud.polaris.stat.pushgateway.push-interval=1000")
+			.withPropertyValues("spring.cloud.polaris.stat.pushgateway.override-host=127.0.0.1")
 			.withPropertyValues("spring.cloud.gateway.enabled=false");
 
 	@Test
@@ -61,6 +62,7 @@ public class PolarisStatPropertiesTest {
 			assertThat(polarisStatProperties.getStatNamespace()).isEqualTo("test-namespace");
 			assertThat(polarisStatProperties.getStatService()).isEqualTo("test-service");
 			assertThat(polarisStatProperties.getPushGatewayPushInterval().toString()).isEqualTo("1000");
+			assertThat(polarisStatProperties.getPushGatewayOverrideHost()).isEqualTo("127.0.0.1");
 		});
 	}
 

--- a/spring-cloud-tencent-rpc-enhancement/src/test/java/com/tencent/cloud/rpc/enhancement/stat/config/StatConfigModifierTest.java
+++ b/spring-cloud-tencent-rpc-enhancement/src/test/java/com/tencent/cloud/rpc/enhancement/stat/config/StatConfigModifierTest.java
@@ -57,6 +57,7 @@ public class StatConfigModifierTest {
 			.withPropertyValues("spring.cloud.polaris.stat.pushgateway.open-gzip=true")
 			.withPropertyValues("spring.cloud.polaris.stat.pushgateway.namespace=test-namespace")
 			.withPropertyValues("spring.cloud.polaris.stat.pushgateway.service=test-service")
+			.withPropertyValues("spring.cloud.polaris.stat.pushgateway.override-host=127.0.0.1")
 			.withPropertyValues("spring.application.name=test")
 			.withPropertyValues("spring.cloud.gateway.enabled=false");
 
@@ -97,6 +98,7 @@ public class StatConfigModifierTest {
 			assertThat(prometheusHandlerConfig.isOpenGzip()).isTrue();
 			assertThat(prometheusHandlerConfig.getNamespace()).isEqualTo("test-namespace");
 			assertThat(prometheusHandlerConfig.getService()).isEqualTo("test-service");
+			assertThat(prometheusHandlerConfig.getOverrideHost()).isEqualTo("127.0.0.1");
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Add `limiterOverrideHost` property to `PolarisRateLimitProperties` for overriding remote rate limiter service host
- Add `overrideHost` property to `PushGatewayEventReporterProperties` for overriding push gateway event reporter host
- Add `pushGatewayOverrideHost` property to `PolarisStatProperties` for overriding Prometheus push gateway host
- All three properties allow replacing discovered instance IPs with a specified host while preserving original ports
- Updated corresponding ConfigModifier classes to propagate the new settings to polaris-java SDK
- Added unit tests for all new properties and config modifiers

## Test plan
- [x] Unit tests added for `PolarisRateLimitProperties`, `RateLimitConfigModifier`
- [x] Unit tests added for `PushGatewayEventReporterProperties`, `PushGatewayEventReporterConfigModifier`
- [x] Unit tests added for `PolarisStatProperties`, `StatConfigModifier`
- [ ] Run full CI (JUnit + Checkstyle + License Header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)