### PR TITLE
fix: add condition for eager load autoconfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - [test: add unit tests for ConfigurationModifier and fix TsfConsul report logic](https://github.com/Tencent/spring-cloud-tencent/pull/1802)
 - [fix: prepend context-path to contract reporter API paths](https://github.com/Tencent/spring-cloud-tencent/pull/1803)
 - [feat: support overrideHost configuration for ratelimit, event reporter and stat modules](https://github.com/Tencent/spring-cloud-tencent/pull/1804)
+- [fix: add condition for eager load autoconfiguration](https://github.com/Tencent/spring-cloud-tencent/pull/1805)

--- a/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/eager/config/PolarisEagerLoadAutoConfiguration.java
+++ b/spring-cloud-starter-tencent-polaris-discovery/src/main/java/com/tencent/cloud/polaris/eager/config/PolarisEagerLoadAutoConfiguration.java
@@ -47,6 +47,7 @@ public class PolarisEagerLoadAutoConfiguration {
 			LoadBalancerEagerLoadProperties loadBalancerEagerLoadProperties) {
 		return new FeignEagerLoadContextInitializer(applicationContext, loadBalancerClientFactory, loadBalancerEagerLoadProperties);
 	}
+
 	@Bean
 	@ConditionalOnProperty(name = "spring.cloud.polaris.discovery.eager-load.services.enabled", havingValue = "true", matchIfMissing = true)
 	public ServicesEagerLoadSmartLifecycle serviceEagerLoadSmartLifecycle(
@@ -57,6 +58,7 @@ public class PolarisEagerLoadAutoConfiguration {
 
 	@Bean
 	@ConditionalOnProperty(value = "spring.cloud.loadbalancer.eager-load.enabled", matchIfMissing = true)
+	@ConditionalOnClass(name = "org.springframework.cloud.loadbalancer.support.LoadBalancerClientFactory")
 	public LoadBalancerEagerContextInitializer loadBalancerEagerContextInitializer(
 			LoadBalancerClientFactory loadBalancerClientFactory, LoadBalancerEagerLoadProperties properties) {
 		return new LoadBalancerEagerContextInitializer(loadBalancerClientFactory, properties.getClients());


### PR DESCRIPTION
## PR Type
Bugfix.
javaagent场景下，provider如果没有引入spring-cloud-loadbalancer依赖，会导致loadBalancerEagerContextInitializer无法初始化
<!--
Bugfix.
Feature.
Code style update (formatting, local variables).
Refactoring (no functional changes, no api changes).
Documentation content changes.
Other... Please describe:
 -->

## Describe what this PR does for and how you did.

## Adding the issue link (#xxx) if possible.

<!--
closes #
 -->

## Note

## Checklist

- [ ] Add information of this PR to CHANGELOG.md in root of project.
- [ ] Add documentation in javadoc or comment below the PR if necessary.
